### PR TITLE
fix: update SDK icon colors to use accent theme

### DIFF
--- a/frontend/src/lib/components/Docs.svelte
+++ b/frontend/src/lib/components/Docs.svelte
@@ -1438,6 +1438,7 @@ terminal.write('ls -la\\n');</code></pre>
         font-size: 24px;
         width: 36px;
         text-align: center;
+        color: var(--accent);
     }
 
     .sdk-info h4 {
@@ -1495,7 +1496,7 @@ terminal.write('ls -la\\n');</code></pre>
         background: var(--bg-tertiary);
         border: 1px solid var(--border);
         border-radius: 6px;
-        color: var(--text);
+        color: var(--accent);
         text-decoration: none;
         font-size: 13px;
         font-weight: 500;
@@ -1504,7 +1505,7 @@ terminal.write('ls -la\\n');</code></pre>
 
     .sdk-link:hover {
         border-color: var(--accent);
-        color: var(--accent);
+        background: rgba(0, 255, 65, 0.05);
     }
 
     /* Architecture */

--- a/frontend/src/lib/components/UseCases.svelte
+++ b/frontend/src/lib/components/UseCases.svelte
@@ -655,6 +655,7 @@
         border-radius: 8px;
         text-decoration: none;
         transition: all 0.2s ease;
+        color: var(--accent);
     }
 
     .sdk-lang:hover {
@@ -758,12 +759,12 @@
     .sdk-btn.secondary {
         background: var(--bg-secondary);
         border: 1px solid var(--border);
-        color: var(--text);
+        color: var(--accent);
     }
 
     .sdk-btn.secondary:hover {
         border-color: var(--accent);
-        color: var(--accent);
+        background: rgba(0, 255, 65, 0.05);
     }
 
     .cta-section {


### PR DESCRIPTION
- Use var(--accent) for SDK icons instead of default/blue
- Consistent green theme throughout SDK sections