### PR TITLE
fix: add sdkDocs to LazyComponentKey type

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -111,6 +111,7 @@
         | "marketplacePage"
         | "agentDocs"
         | "cliDocs"
+        | "sdkDocs"
         | "embedDocs"
         | "docs"
         | "cliLogin"

--- a/frontend/src/lib/components/SDKDocs.svelte
+++ b/frontend/src/lib/components/SDKDocs.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import StatusIcon from "./icons/StatusIcon.svelte";
-    import { auth } from "$stores/auth";
 
     export let onback: (() => void) | undefined = undefined;
 
@@ -16,8 +15,6 @@
     function handleBack() {
         if (onback) onback();
     }
-
-    $: currentToken = $auth.token || "YOUR_API_TOKEN";
 
     const sdks = [
         { id: "go", name: "Go", install: "go get github.com/PipeOpsHQ/rexec-go", github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/go" },


### PR DESCRIPTION
This pull request introduces a small change to the application by adding a new route identifier. The change expands the set of recognized page types in the app.

- Added the `"sdkDocs"` route to the list of recognized page types in `App.svelte`.