### PR TITLE
refactor: Use uint16 type for resizing terminal rows and columns

### DIFF
--- a/cmd/rexec-guest-agent/main.go
+++ b/cmd/rexec-guest-agent/main.go
@@ -27,6 +27,7 @@ func main() {
 		listenAddr = flag.String("listen", "", "Address to listen on (vsock or tcp)")
 	)
 	flag.Parse()
+	_ = tcpPort // reserved for TCP fallback when vsock not available
 
 	server := &GuestAgentServer{
 		vsockPort: *vsockPort,

--- a/internal/api/handlers/terminal_vm.go
+++ b/internal/api/handlers/terminal_vm.go
@@ -159,7 +159,7 @@ func (h *TerminalHandler) handleVMInput(session *TerminalSession, writer io.Writ
 				var msg TerminalMessage
 				if err := json.Unmarshal(data, &msg); err == nil {
 					if msg.Type == "resize" && resize != nil {
-						if err := resize(msg.Cols, msg.Rows); err != nil {
+						if err := resize(uint16(msg.Cols), uint16(msg.Rows)); err != nil {
 							log.Printf("[Terminal] Failed to resize VM terminal: %v", err)
 						}
 						session.Cols = uint(msg.Cols)

--- a/internal/api/handlers/vm.go
+++ b/internal/api/handlers/vm.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"net/http"
 	"strings"
 

--- a/internal/firecracker/guest_agent.go
+++ b/internal/firecracker/guest_agent.go
@@ -310,7 +310,7 @@ func (c *GuestAgentClient) Shell(ctx context.Context, shell string, cols, rows u
 		"rows":   rows,
 	}
 
-	resp, err := c.Call(ctx, "shell", params)
+	_, err := c.Call(ctx, "shell", params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request includes several small bug fixes and code cleanups across the Firecracker VM management and API handler code. The changes improve type safety, remove unused code, and enhance the fallback logic for VM resource statistics.

Key changes include:

**Type safety and bug fixes:**

* Fixed a bug in the terminal resize handler by explicitly converting `msg.Cols` and `msg.Rows` to `uint16` before passing them to the resize function, ensuring correct terminal sizing.
* Improved the fallback logic for VM resource statistics by parsing memory and disk limits from string labels, handling conversion to `int64` safely, and avoiding incorrect multiplication.

**Code cleanup and simplification:**

* Removed unused imports (`context`, `crypto/rand`) from `vm.go` and `manager.go`, reducing unnecessary dependencies. [[1]](diffhunk://#diff-9093f4f8e991ad625d8ce38d375acc65125cf12aa355899089550d7bb80d87c5L4) [[2]](diffhunk://#diff-c70a3e1a52dc7f7928c23bf8d9f14c9329cfb6e762f0720eb277d4cfac34bd13L5)
* Removed an unused variable declaration in the Firecracker manager's `Start` method, simplifying the code.
* Removed an unused variable in the `Exec` method of the Firecracker manager, cleaning up the code.
* Suppressed the unused variable warning for `tcpPort` in the guest agent main function, making the intent clear for future TCP fallback support.

**API response handling:**

* Updated the guest agent client's `Shell` method to ignore the response body, as it was not being used, and only return errors if present.