### PR TITLE
refactor: Remove duplicated code for gating privileged macOS VM containers

### DIFF
--- a/internal/api/handlers/container.go
+++ b/internal/api/handlers/container.go
@@ -249,22 +249,6 @@ func (h *ContainerHandler) Create(c *gin.Context) {
 		}
 	}
 
-	// Gate privileged macOS VM containers to enterprise/admin users only.
-	if req.Image == "macos" || req.Image == "macos-legacy" {
-		user, err := h.store.GetUserByID(ctx, userID)
-		if err != nil || user == nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
-			return
-		}
-		if tier != "enterprise" && !user.IsAdmin {
-			c.JSON(http.StatusForbidden, gin.H{
-				"error":   "macOS containers are restricted",
-				"message": "macOS images require enterprise tier or admin access",
-			})
-			return
-		}
-	}
-
 	// Auto-generate name if not provided
 	containerName := strings.TrimSpace(req.Name)
 	if containerName == "" {
@@ -1651,27 +1635,6 @@ func (h *ContainerHandler) CreateWithProgress(c *gin.Context) {
 			sendEvent(container.ProgressEvent{
 				Stage:    "validating",
 				Error:    "unsupported image type",
-				Complete: true,
-			})
-			return
-		}
-	}
-
-	// Gate privileged macOS VM containers to enterprise/admin users only.
-	if req.Image == "macos" || req.Image == "macos-legacy" {
-		user, err := h.store.GetUserByID(ctx, userID)
-		if err != nil || user == nil {
-			sendEvent(container.ProgressEvent{
-				Stage:    "validating",
-				Error:    "user not found",
-				Complete: true,
-			})
-			return
-		}
-		if tier != "enterprise" && !user.IsAdmin {
-			sendEvent(container.ProgressEvent{
-				Stage:    "validating",
-				Error:    "macOS images require enterprise tier or admin access",
 				Complete: true,
 			})
 			return


### PR DESCRIPTION
This pull request removes the restriction that previously allowed only enterprise tier or admin users to create containers using the `macos` or `macos-legacy` images. Now, any user can request these images without additional privilege checks in both the standard and progress-tracking container creation endpoints.

Access control changes for macOS container creation:

* Removed the privilege check in `ContainerHandler.Create` that gated `macos` and `macos-legacy` image requests to enterprise or admin users only.
* Removed the corresponding privilege check in `ContainerHandler.CreateWithProgress`, so macOS image requests are no longer restricted in the progress-tracking endpoint.