### PR TITLE
refactor: Update macOS image descriptions and tags for clarity and consistency

### DIFF
--- a/frontend/src/lib/components/InlineCreateTerminal.svelte
+++ b/frontend/src/lib/components/InlineCreateTerminal.svelte
@@ -455,11 +455,11 @@
             category: "embedded",
         },
 
-        // macOS (CUA Lumier image)
+        // macOS (VM-based, docker-osx)
         {
             name: "macos",
-            display_name: "macOS (Sequoia)",
-            description: "Apple macOS Sequoia (CUA Lumier, VM-based)",
+            display_name: "macOS",
+            description: "Apple macOS (VM-based)",
             category: "macos",
             popular: true,
         },

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -193,9 +193,9 @@ var SupportedImages = map[string]string{
 	"photon":     "photon:5.0", // VMware Photon OS 5.0
 	// Raspberry Pi / ARM
 	"raspberrypi": "balenalib/raspberry-pi-debian:bookworm",
-	// macOS (VM-based) - CUA Lumier image (https://cua.ai/docs/lume/guide/advanced/lumier/docker)
-	"macos":        "ghcr.io/trycua/macos-sequoia-cua:latest", // macOS Sequoia (CUA)
-	"macos-legacy": "sickcodes/docker-osx:big-sur",            // Big Sur (legacy)
+	// macOS (VM-based) - docker-osx (ghcr.io/trycua/macos-sequoia-cua not pullable as standalone image)
+	"macos":        "sickcodes/docker-osx:latest",  // Catalina
+	"macos-legacy": "sickcodes/docker-osx:big-sur", // Big Sur
 }
 
 // CustomImages maps to rexec custom images with SSH pre-installed
@@ -301,8 +301,8 @@ func GetImageMetadata() []ImageMetadata {
 		// Raspberry Pi / ARM
 		{Name: "raspberrypi", DisplayName: "Raspberry Pi OS", Description: "Debian-based OS for Raspberry Pi/ARM", Category: "embedded", Tags: []string{"raspberry-pi", "arm", "iot"}, Popular: false},
 
-		// macOS - CUA Lumier image
-		{Name: "macos", DisplayName: "macOS (Sequoia)", Description: "Apple macOS Sequoia (CUA Lumier, VM-based)", Category: "macos", Tags: []string{"macos", "apple", "vm", "sequoia"}, Popular: true},
+		// macOS (VM-based, docker-osx)
+		{Name: "macos", DisplayName: "macOS (Catalina)", Description: "Apple macOS Catalina (VM-based)", Category: "macos", Tags: []string{"macos", "apple", "vm"}, Popular: true},
 		{Name: "macos-legacy", DisplayName: "macOS (Big Sur)", Description: "Apple macOS Big Sur (VM-based)", Category: "macos", Tags: []string{"macos", "apple", "vm", "legacy"}, Popular: false},
 	}
 }


### PR DESCRIPTION
This pull request updates our support for macOS container images, moving away from the CUA Lumier image to use the more widely available `docker-osx` images. The changes affect both the backend container management and the frontend display information to ensure consistency and clarity for users.

**Container image updates:**

* Switched the default macOS image from `ghcr.io/trycua/macos-sequoia-cua:latest` (CUA Lumier) to `sickcodes/docker-osx:latest` (Catalina), as the former is not pullable as a standalone image. The legacy image for Big Sur remains unchanged. (`internal/container/manager.go`)

**Frontend and metadata consistency:**

* Updated the frontend display name and description for the macOS image to remove references to "Sequoia" and "CUA Lumier", reflecting the new VM-based `docker-osx` image. (`frontend/src/lib/components/InlineCreateTerminal.svelte`)
* Adjusted the backend image metadata to match the new image, updating the display name to "macOS (Catalina)" and removing outdated tags and references. (`internal/container/manager.go`)