### PR TITLE
fix: Remove duplicate Active now status on container cards

### DIFF
--- a/frontend/src/lib/components/Dashboard.svelte
+++ b/frontend/src/lib/components/Dashboard.svelte
@@ -1000,19 +1000,6 @@
                         {/if}
                     </div>
 
-                    {#if isAgent && container.status === "running" && container.idle_seconds !== undefined}
-                        <div class="activity-indicator">
-                            <span class="activity-dot" class:active={container.idle_seconds < 60}></span>
-                            <span class="activity-text">
-                                {container.idle_seconds < 60
-                                    ? "Active now"
-                                    : container.idle_seconds < 300
-                                      ? "Active recently"
-                                      : `Idle ${Math.floor(container.idle_seconds / 60)}m`}
-                            </span>
-                        </div>
-                    {/if}
-
                     {#if container.resources}
                         <div class="container-resources">
                             <span class="resource-spec" title="Memory">


### PR DESCRIPTION
## Summary
Fixes duplicate "Active now" (and other activity) status on container cards.

## Problem
Agent cards showed the activity indicator twice: once from an agent-only block and once from the shared block that runs for all running containers with `idle_seconds`.

## Fix
Removed the agent-specific activity indicator block. A single activity indicator now shows for all running containers (regular and agent) when `idle_seconds` is present.

## File
- `frontend/src/lib/components/Dashboard.svelte`

Made with [Cursor](https://cursor.com)