### PR TITLE
feat: add email-based collaboration invitations

### DIFF
--- a/cmd/rexec/main.go
+++ b/cmd/rexec/main.go
@@ -813,6 +813,12 @@ func runServer() {
 			collab.GET("/join/:code", collabHandler.JoinSession)
 			collab.DELETE("/sessions/:id", collabHandler.EndSession)
 			collab.GET("/sessions", collabHandler.GetActiveSessions)
+			// Invitation endpoints
+			collab.POST("/sessions/:id/invite", collabHandler.SendInvitation)
+			collab.GET("/sessions/:id/invitations", collabHandler.GetSessionInvitations)
+			collab.GET("/invitations", collabHandler.GetMyInvitations)
+			collab.POST("/invitations/:id/respond", collabHandler.RespondToInvitation)
+			collab.DELETE("/invitations/:id", collabHandler.DeleteInvitation)
 		}
 
 		// Recording endpoints

--- a/frontend/src/lib/components/Dashboard.svelte
+++ b/frontend/src/lib/components/Dashboard.svelte
@@ -335,6 +335,11 @@
             openMfaVerifyModal(container);
             return;
         }
+        // For shared terminals, navigate to the collab join page
+        if (container.shared && container.share_code) {
+            window.location.href = `/join/${container.share_code}`;
+            return;
+        }
         // Mark as connecting immediately
         connectingIds.add(container.id);
         connectingIds = new Set(connectingIds); // Trigger reactivity


### PR DESCRIPTION
## Summary

Adds the ability to invite users by email to join a terminal collaboration session. Instead of only sharing a link, terminal owners can now invite specific users by their email address. The invited user receives an in-app notification and can accept or decline.

## Features

### Backend
- New `collab_invitations` database table with unique constraint per session/user
- Storage functions: `CreateCollabInvitation`, `GetPendingInvitationsForUser`, `GetInvitationsForSession`, `RespondToInvitation`, `DeleteCollabInvitation`
- New API endpoints:
  - `POST /api/collab/sessions/:id/invite` - Send invitation by email
  - `GET /api/collab/sessions/:id/invitations` - List invitations for a session (owner only)
  - `GET /api/collab/invitations` - Get pending invitations for current user
  - `POST /api/collab/invitations/:id/respond` - Accept or decline invitation
  - `DELETE /api/collab/invitations/:id` - Cancel invitation (owner only)

### Frontend
- **CollabPanel**: Added "Invite by Email" section when session is active
  - Email input with send button
  - Success/error feedback
  - List of pending invitations with cancel option
- **Header**: Added notification bell showing pending invitations
  - Badge with count when invitations are pending
  - Dropdown menu showing invitations with Accept/Decline buttons
  - Auto-polls for new invitations every 30 seconds
- **Collab Store**: Added invitation functions (`sendInvitation`, `getMyInvitations`, `respondToInvitation`, etc.)

## Flow

1. Owner starts a collab session
2. Owner enters collaborator's email and clicks "Send"
3. If user exists, invitation is created (pending status)
4. Collaborator sees notification bell with badge count
5. Collaborator clicks bell, sees invitation details
6. Collaborator clicks "Accept" -> automatically joins the session
7. Or clicks "Decline" -> invitation is dismissed

## Testing

- `go build ./...` - passes
- `npm run check` - 0 errors, 175 warnings (pre-existing)