### PR TITLE
docs: add agent uninstall instructions to AGENTS.md

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -187,6 +187,44 @@ sudo systemctl restart rexec-agent
 sudo journalctl -u rexec-agent -f
 ```
 
+### Uninstalling the Agent
+
+To completely remove the Rexec agent from your system, use the install script with the `--uninstall` flag:
+
+```bash
+curl -fsSL https://rexec.sh/install-agent.sh | sudo bash -s -- --uninstall
+```
+
+This will:
+
+- Stop and disable the agent service (systemd, launchd, or sysvinit)
+- Remove the agent binary from `/usr/local/bin/rexec-agent`
+- Remove the configuration directory `/etc/rexec/`
+- Remove log files from `/var/log/rexec-agent.log`
+
+**Manual uninstall (if needed):**
+
+```bash
+# Linux (systemd)
+sudo systemctl stop rexec-agent
+sudo systemctl disable rexec-agent
+sudo rm /etc/systemd/system/rexec-agent.service
+sudo systemctl daemon-reload
+sudo rm /usr/local/bin/rexec-agent
+sudo rm -rf /etc/rexec
+sudo rm /var/log/rexec-agent.log
+
+# macOS (launchd)
+sudo launchctl stop io.pipeops.rexec-agent
+sudo launchctl unload /Library/LaunchDaemons/io.pipeops.rexec-agent.plist
+sudo rm /Library/LaunchDaemons/io.pipeops.rexec-agent.plist
+sudo rm /usr/local/bin/rexec-agent
+sudo rm -rf /etc/rexec
+sudo rm /var/log/rexec-agent.log /var/log/rexec-agent.error.log
+```
+
+**Note:** Uninstalling the agent does not automatically remove the agent entry from your Rexec dashboard. To fully remove the agent, also delete it from **Settings → Agents** in the dashboard.
+
 ## Environment Variables
 
 | Variable       | Description                                 |


### PR DESCRIPTION
This pull request adds comprehensive instructions for uninstalling the Rexec agent to the documentation, making it easier for users to fully remove the agent from their systems. The new section covers both automated and manual uninstall steps for Linux and macOS, and clarifies dashboard cleanup requirements.

Documentation improvements:

* Added a new "Uninstalling the Agent" section to `docs/AGENTS.md`, including a one-line uninstall command using the install script with the `--uninstall` flag.
* Detailed the steps performed by the uninstall script: stopping/disabling the service, removing binaries, configuration, and log files.
* Provided manual uninstall instructions for both Linux (systemd) and macOS (launchd), listing all relevant commands and files to remove.
* Added a note reminding users to also delete the agent entry from the dashboard for complete removal.