### PR TITLE
feat(container_events): Add functionality to broadcast events to collaborators

### DIFF
--- a/internal/api/handlers/container_events.go
+++ b/internal/api/handlers/container_events.go
@@ -504,21 +504,62 @@ func (h *ContainerEventsHub) NotifyContainerProgress(userID string, progressData
 }
 
 // NotifyAgentConnected notifies a user that an agent connected
+// Also broadcasts to all collaborators who have access to this agent
 func (h *ContainerEventsHub) NotifyAgentConnected(userID string, agentData interface{}) {
-	h.BroadcastToUser(userID, ContainerEvent{
+	event := ContainerEvent{
 		Type:      "agent_connected",
 		Container: agentData,
 		Timestamp: time.Now(),
-	})
+	}
+
+	// Broadcast to the owner
+	h.BroadcastToUser(userID, event)
+
+	// Extract agent ID to find collaborators
+	if data, ok := agentData.(gin.H); ok {
+		if id, ok := data["id"].(string); ok && strings.HasPrefix(id, "agent:") {
+			// Also broadcast to all collaborators who have access to this agent
+			h.broadcastToCollaborators(id, event)
+		}
+	}
 }
 
 // NotifyAgentDisconnected notifies a user that an agent disconnected
+// Also broadcasts to all collaborators who have access to this agent
 func (h *ContainerEventsHub) NotifyAgentDisconnected(userID string, agentID string) {
-	h.BroadcastToUser(userID, ContainerEvent{
+	containerID := "agent:" + agentID
+	event := ContainerEvent{
 		Type:      "agent_disconnected",
-		Container: gin.H{"id": "agent:" + agentID},
+		Container: gin.H{"id": containerID},
 		Timestamp: time.Now(),
-	})
+	}
+
+	// Broadcast to the owner
+	h.BroadcastToUser(userID, event)
+
+	// Also broadcast to all collaborators who have access to this agent
+	h.broadcastToCollaborators(containerID, event)
+}
+
+// broadcastToCollaborators sends an event to all collaborators who have access to a container/agent
+func (h *ContainerEventsHub) broadcastToCollaborators(containerID string, event ContainerEvent) {
+	if h.store == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	collaboratorIDs, err := h.store.GetCollaboratorUserIDsForContainer(ctx, containerID)
+	if err != nil {
+		log.Printf("[ContainerEvents] Failed to get collaborators for %s: %v", containerID, err)
+		return
+	}
+
+	// Broadcast to each collaborator
+	for _, collabUserID := range collaboratorIDs {
+		h.BroadcastToUser(collabUserID, event)
+	}
 }
 
 // NotifyAgentStatsUpdated notifies a user that an agent's stats have been updated

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -2073,6 +2073,36 @@ func (s *PostgresStore) GetActiveCollabSessionsForParticipant(ctx context.Contex
 	return sessions, nil
 }
 
+// GetCollaboratorUserIDsForContainer returns all unique user IDs who are active participants
+// in collab sessions for a specific container/agent. This is used to broadcast agent status
+// updates to all collaborators, not just the owner.
+func (s *PostgresStore) GetCollaboratorUserIDsForContainer(ctx context.Context, containerID string) ([]string, error) {
+	query := `
+		SELECT DISTINCT cp.user_id
+		FROM collab_participants cp
+		INNER JOIN collab_sessions cs ON cp.session_id = cs.id
+		WHERE cs.container_id = $1
+		  AND cs.is_active = true
+		  AND cs.expires_at > NOW()
+		  AND cp.left_at IS NULL
+	`
+	rows, err := s.db.QueryContext(ctx, query, containerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var userIDs []string
+	for rows.Next() {
+		var userID string
+		if err := rows.Scan(&userID); err != nil {
+			return nil, err
+		}
+		userIDs = append(userIDs, userID)
+	}
+	return userIDs, nil
+}
+
 // ============================================================================
 // Collaboration Invitations
 // ============================================================================


### PR DESCRIPTION
This pull request enhances the notification system for agent connection and disconnection events by ensuring that all collaborators with access to a given agent are notified, not just the owner. It introduces new logic to identify collaborators and broadcast relevant events to them, and adds a database method to efficiently retrieve collaborator user IDs for a specific container or agent.

**Event Broadcasting Improvements:**

* Updated `NotifyAgentConnected` and `NotifyAgentDisconnected` methods in `container_events.go` to broadcast agent connection and disconnection events to all collaborators who have access to the agent, in addition to the owner.
* Added a new helper method `broadcastToCollaborators` in `container_events.go` to handle broadcasting events to all relevant collaborators based on agent/container ID.

**Database Support for Collaboration:**

* Added `GetCollaboratorUserIDsForContainer` method to `PostgresStore` in `postgres.go`, which queries the database to return all unique user IDs of active participants in collaborative sessions for a specific container or agent. This supports the new event broadcasting logic.