### PR TITLE
feat: Add method to check agent online status and use it in container handler

### DIFF
--- a/internal/api/handlers/agent.go
+++ b/internal/api/handlers/agent.go
@@ -1759,6 +1759,28 @@ func (h *AgentHandler) userHasAnyAgentSession(userID, agentID string) bool {
 	return false
 }
 
+// IsAgentOnline checks if an agent is currently connected (locally or via Redis)
+// This is used by shared terminal logic to determine accurate online status
+func (h *AgentHandler) IsAgentOnline(agentID string) bool {
+	// Check local connection first
+	h.agentsMu.RLock()
+	_, isLocal := h.agents[agentID]
+	h.agentsMu.RUnlock()
+	if isLocal {
+		return true
+	}
+
+	// Check Redis for remote agent location (agent connected to another instance)
+	if h.pubsubHub != nil {
+		_, found := h.pubsubHub.GetAgentLocation(agentID)
+		if found {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (h *AgentHandler) countDistinctAgentTerminalsForUser(userID string) int {
 	agentIDs := make(map[string]struct{})
 

--- a/internal/api/handlers/container.go
+++ b/internal/api/handlers/container.go
@@ -238,9 +238,14 @@ func (h *ContainerHandler) GetSharedTerminalsForUser(ctx context.Context, userID
 					continue
 				}
 
-				// Determine online status
-				threshold := time.Now().Add(-2 * time.Minute)
-				isOnline := !agent.LastPing.IsZero() && agent.LastPing.After(threshold)
+				// Determine online status - check if agent is actually connected
+				// First check real-time connection status (local or via Redis)
+				isOnline := h.agentHandler.IsAgentOnline(agentID)
+				// Fallback to LastPing check if not found in active connections
+				if !isOnline {
+					threshold := time.Now().Add(-2 * time.Minute)
+					isOnline = !agent.LastPing.IsZero() && agent.LastPing.After(threshold)
+				}
 				status := "offline"
 				if isOnline {
 					status = "running"


### PR DESCRIPTION
This pull request improves the accuracy of agent online status detection for shared terminal features by introducing a new method to check real-time agent connectivity, both locally and across distributed instances via Redis. The changes ensure that the system more reliably reports whether agents are actually online, rather than relying solely on historical ping data.

Enhancements to agent online status detection:

* Added the `IsAgentOnline` method to `AgentHandler` in `internal/api/handlers/agent.go`, which checks for real-time agent connectivity locally and via Redis, providing a more accurate online status.

Improvements to shared terminal logic:

* Updated the shared terminal status determination in `internal/api/handlers/container.go` to use the new `IsAgentOnline` method, falling back to the previous LastPing check only if real-time connectivity is not found.