### PR TITLE
fix: admin stats timeline data and loading state bugs

### DIFF
--- a/frontend/src/lib/components/AdminDashboard.svelte
+++ b/frontend/src/lib/components/AdminDashboard.svelte
@@ -529,7 +529,7 @@
                                             {term.status}
                                         </span>
                                     </td>
-                                    <td>{formatRelativeTime(term.connected_at)}</td>
+                                    <td>{formatRelativeTime(term.connectedAt)}</td>
                                 </tr>
                             {/each}
                         </tbody>

--- a/frontend/src/lib/stores/admin.ts
+++ b/frontend/src/lib/stores/admin.ts
@@ -23,7 +23,7 @@ export interface AdminTerminal {
   status: "connected" | "disconnected" | "error";
   userId: string;
   username: string;
-  connected_at: string;
+  connectedAt: string;
 }
 
 export interface AdminAgent {
@@ -106,6 +106,7 @@ export interface AdminState {
   terminals: AdminTerminal[];
   agents: AdminAgent[];
   stats: AdminUsageStats | null;
+  _loadingCount: number;
   isLoading: boolean;
   error: string | null;
   ws: WebSocket | null;
@@ -121,6 +122,7 @@ const initialState: AdminState = {
   terminals: [],
   agents: [],
   stats: null,
+  _loadingCount: 0,
   isLoading: false,
   error: null,
   ws: null,
@@ -308,81 +310,170 @@ function createAdminStore() {
   return {
     subscribe,
     fetchUsers: async () => {
-      update((state) => ({ ...state, isLoading: true, error: null }));
+      update((state) => ({
+        ...state,
+        _loadingCount: state._loadingCount + 1,
+        isLoading: true,
+        error: null,
+      }));
       const { data, error } = await api.get<AdminUser[]>("/api/admin/users");
 
       if (error) {
-        update((state) => ({ ...state, isLoading: false, error }));
+        update((state) => {
+          const count = state._loadingCount - 1;
+          return {
+            ...state,
+            _loadingCount: count,
+            isLoading: count > 0,
+            error,
+          };
+        });
         return;
       }
-      update((state) => ({ ...state, users: data || [], isLoading: false }));
+      update((state) => {
+        const count = state._loadingCount - 1;
+        return {
+          ...state,
+          users: data || [],
+          _loadingCount: count,
+          isLoading: count > 0,
+        };
+      });
     },
 
     fetchContainers: async () => {
-      update((state) => ({ ...state, isLoading: true, error: null }));
+      update((state) => ({
+        ...state,
+        _loadingCount: state._loadingCount + 1,
+        isLoading: true,
+        error: null,
+      }));
       const { data, error } = await api.get<AdminContainer[]>(
         "/api/admin/containers",
       );
 
       if (error) {
-        update((state) => ({ ...state, isLoading: false, error }));
+        update((state) => {
+          const count = state._loadingCount - 1;
+          return {
+            ...state,
+            _loadingCount: count,
+            isLoading: count > 0,
+            error,
+          };
+        });
         return;
       }
-      update((state) => ({
-        ...state,
-        containers: data || [],
-        isLoading: false,
-      }));
+      update((state) => {
+        const count = state._loadingCount - 1;
+        return {
+          ...state,
+          containers: data || [],
+          _loadingCount: count,
+          isLoading: count > 0,
+        };
+      });
     },
 
     fetchTerminals: async () => {
-      update((state) => ({ ...state, isLoading: true, error: null }));
+      update((state) => ({
+        ...state,
+        _loadingCount: state._loadingCount + 1,
+        isLoading: true,
+        error: null,
+      }));
       const { data, error } = await api.get<AdminTerminal[]>(
         "/api/admin/terminals",
       );
 
       if (error) {
-        update((state) => ({ ...state, isLoading: false, error }));
+        update((state) => {
+          const count = state._loadingCount - 1;
+          return {
+            ...state,
+            _loadingCount: count,
+            isLoading: count > 0,
+            error,
+          };
+        });
         return;
       }
-      update((state) => ({
-        ...state,
-        terminals: data || [],
-        isLoading: false,
-      }));
+      update((state) => {
+        const count = state._loadingCount - 1;
+        return {
+          ...state,
+          terminals: data || [],
+          _loadingCount: count,
+          isLoading: count > 0,
+        };
+      });
     },
 
     fetchAgents: async () => {
-      update((state) => ({ ...state, isLoading: true, error: null }));
+      update((state) => ({
+        ...state,
+        _loadingCount: state._loadingCount + 1,
+        isLoading: true,
+        error: null,
+      }));
       const { data, error } = await api.get<AdminAgent[]>("/api/admin/agents");
 
       if (error) {
-        update((state) => ({ ...state, isLoading: false, error }));
+        update((state) => {
+          const count = state._loadingCount - 1;
+          return {
+            ...state,
+            _loadingCount: count,
+            isLoading: count > 0,
+            error,
+          };
+        });
         return;
       }
-      update((state) => ({
-        ...state,
-        agents: data || [],
-        isLoading: false,
-      }));
+      update((state) => {
+        const count = state._loadingCount - 1;
+        return {
+          ...state,
+          agents: data || [],
+          _loadingCount: count,
+          isLoading: count > 0,
+        };
+      });
     },
 
     fetchStats: async (range = "30d") => {
-      update((state) => ({ ...state, isLoading: true, error: null }));
+      update((state) => ({
+        ...state,
+        _loadingCount: state._loadingCount + 1,
+        isLoading: true,
+        error: null,
+      }));
       const { data, error } = await api.get<AdminUsageStats>(
         `/api/admin/stats?range=${encodeURIComponent(range)}`,
       );
 
       if (error) {
-        update((state) => ({ ...state, isLoading: false, error }));
+        update((state) => {
+          const count = state._loadingCount - 1;
+          return {
+            ...state,
+            _loadingCount: count,
+            isLoading: count > 0,
+            error,
+          };
+        });
         return;
       }
 
-      update((state) => ({
-        ...state,
-        stats: data || null,
-        isLoading: false,
-      }));
+      update((state) => {
+        const count = state._loadingCount - 1;
+        return {
+          ...state,
+          stats: data || null,
+          _loadingCount: count,
+          isLoading: count > 0,
+        };
+      });
     },
 
     deleteUser: async (userId: string) => {

--- a/internal/storage/postgres_admin.go
+++ b/internal/storage/postgres_admin.go
@@ -12,7 +12,7 @@ import (
 // GetAllUsers retrieves all users for the admin dashboard
 func (s *PostgresStore) GetAllUsers(ctx context.Context) ([]*models.User, error) {
 	query := `
-		SELECT id, email, username, tier, COALESCE(is_admin, false), 
+		SELECT id, email, username, tier, COALESCE(is_admin, false),
 		       COALESCE(pipeops_id, ''), subscription_active, created_at, updated_at
 		FROM users
 		ORDER BY created_at DESC
@@ -52,7 +52,7 @@ func (s *PostgresStore) GetAllUsers(ctx context.Context) ([]*models.User, error)
 // GetContainerCountsByUser returns a map of userID -> active container count.
 func (s *PostgresStore) GetContainerCountsByUser(ctx context.Context) (map[string]int, error) {
 	query := `
-		SELECT user_id, COUNT(*) 
+		SELECT user_id, COUNT(*)
 		FROM containers
 		WHERE deleted_at IS NULL
 		GROUP BY user_id
@@ -79,8 +79,8 @@ func (s *PostgresStore) GetContainerCountsByUser(ctx context.Context) (map[strin
 // It performs a JOIN with users to get owner details
 func (s *PostgresStore) GetAllContainersAdmin(ctx context.Context) ([]*models.AdminContainer, error) {
 	query := `
-		SELECT 
-			c.id, c.user_id, c.name, c.image, c.status, c.created_at, 
+		SELECT
+			c.id, c.user_id, c.name, c.image, c.status, c.created_at,
 			c.memory_mb, c.cpu_shares, c.disk_mb,
 			u.username, u.email
 		FROM containers c
@@ -127,7 +127,7 @@ func (s *PostgresStore) GetAllSessionsAdmin(ctx context.Context) ([]*models.Admi
 	// Although for now, we'll just return all sessions in the table as "active" implies
 	// they haven't been deleted yet.
 	query := `
-		SELECT 
+		SELECT
 			s.id, s.container_id, s.user_id, s.created_at,
 			u.username,
 			c.name as container_name, c.status
@@ -325,7 +325,7 @@ func (s *PostgresStore) fillAdminUsageSeries(ctx context.Context, timeline []mod
 	}
 
 	query := fmt.Sprintf(`
-		SELECT date_trunc('%s', %s) AS bucket, COUNT(*)
+		SELECT date_trunc('%s', %s AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket, COUNT(*)
 		FROM %s
 		WHERE %s >= $1 AND %s < $2
 		GROUP BY 1


### PR DESCRIPTION
## Summary

Fixes three bugs causing the admin stats dashboard to not work correctly.

### Bug 1: Timeline data empty due to `date_trunc` timezone mismatch (Backend)

**Root cause:** The `fillAdminUsageSeries` function uses PostgreSQL's `date_trunc()` to group records into time buckets. However, `date_trunc` on `TIMESTAMP WITH TIME ZONE` columns operates in the **session timezone**, not necessarily UTC. The Go code computes bucket start times in UTC. If the PostgreSQL server timezone isn't UTC, the SQL bucket boundaries don't align with the Go-computed buckets, and the map lookup `points[bucket]` silently fails — resulting in **all-zero timeline data** (empty charts and tables).

**Fix:** Added explicit UTC conversion in the SQL query:
```sql
SELECT date_trunc('day', created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket, COUNT(*)
```

### Bug 2: Loading spinner disappears too early (Frontend)

**Root cause:** The dashboard loads 5 data sources in parallel (`fetchStats`, `fetchUsers`, `fetchContainers`, `fetchTerminals`, `fetchAgents`). Each independently toggles a single `isLoading` boolean. The **first** fetch to complete sets `isLoading: false`, hiding the loading spinner while slower fetches (especially `fetchStats` with 15+ DB queries) are still running. The user sees an empty stats panel with no loading indicator.

**Fix:** Replaced the boolean with a `_loadingCount` counter. Each fetch increments on start, decrements on completion. `isLoading` is only `false` when **all** concurrent fetches finish (`_loadingCount === 0`).

### Bug 3: Terminal "Connected At" column shows undefined (Frontend)

**Root cause:** The Go backend serializes the terminal connection time as `"connectedAt"` (camelCase), but the TypeScript interface declared it as `connected_at` (snake_case). This caused `formatRelativeTime(term.connected_at)` to always receive `undefined`.

**Fix:** Updated the `AdminTerminal` interface and the Svelte template to use `connectedAt`.

## Files Changed

- `internal/storage/postgres_admin.go` — UTC-safe `date_trunc` in `fillAdminUsageSeries`
- `frontend/src/lib/stores/admin.ts` — Loading counter + `connectedAt` interface fix
- `frontend/src/lib/components/AdminDashboard.svelte` — `term.connectedAt` reference fix