### PR TITLE
chore: follow-up to update lingering taglines to AI-Native Sandbox

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,12 +6,12 @@
 
         <!-- Primary Meta Tags -->
         <title>
-            Rexec - Sandbox as a Service | Instant Linux Sandboxes in Your
+            Rexec - AI-Native Sandbox | Instant Linux Sandboxes in Your
             Browser
         </title>
         <meta
             name="title"
-            content="Rexec - Sandbox as a Service | Instant Linux Sandboxes in Your Browser"
+            content="Rexec - AI-Native Sandbox | Instant Linux Sandboxes in Your Browser"
         />
         <meta
             name="description"
@@ -31,7 +31,7 @@
         <!-- Open Graph / Facebook -->
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://rexec.pipeops.io" />
-        <meta property="og:title" content="Rexec - Sandbox as a Service" />
+        <meta property="og:title" content="Rexec - AI-Native Sandbox" />
         <meta
             property="og:description"
             content="Launch secure Linux sandboxes instantly in your browser. No setup required. Choose from Ubuntu, Debian, Alpine, Arch, and more. Perfect for development, testing, demos, and safely running AI-generated code."
@@ -43,14 +43,14 @@
         <meta property="og:image:type" content="image/png" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
-        <meta property="og:image:alt" content="Rexec - Sandbox as a Service" />
+        <meta property="og:image:alt" content="Rexec - AI-Native Sandbox" />
         <meta property="og:site_name" content="Rexec" />
         <meta property="og:locale" content="en_US" />
 
         <!-- Twitter -->
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:url" content="https://rexec.pipeops.io" />
-        <meta name="twitter:title" content="Rexec - Sandbox as a Service" />
+        <meta name="twitter:title" content="Rexec - AI-Native Sandbox" />
         <meta
             name="twitter:description"
             content="Launch secure Linux sandboxes instantly in your browser. No setup required. Choose from Ubuntu, Debian, Alpine, Arch, and more. Perfect for development, testing, demos, and safely running AI-generated code."
@@ -61,7 +61,7 @@
         />
         <meta
             name="twitter:image:alt"
-            content="Rexec - Sandbox as a Service"
+            content="Rexec - AI-Native Sandbox"
         />
 
         <!-- Theme Color -->
@@ -136,7 +136,7 @@
                 "name": "Rexec",
                 "url": "https://rexec.pipeops.io",
                 "logo": "https://rexec.pipeops.io/favicon.svg",
-                "description": "Sandbox as a Service - Instant Linux sandboxes in your browser",
+                "description": "AI-Native Sandbox - Instant Linux sandboxes in your browser",
                 "sameAs": []
             }
         </script>

--- a/frontend/public/.well-known/ai-plugin.json
+++ b/frontend/public/.well-known/ai-plugin.json
@@ -2,7 +2,7 @@
   "schema_version": "v1",
   "name_for_human": "Rexec",
   "name_for_model": "rexec_terminal_service",
-  "description_for_human": "Sandbox as a Service - Instant Linux sandboxes in your browser with Docker-backed execution environments.",
+  "description_for_human": "AI-Native Sandbox - Instant Linux sandboxes in your browser with Docker-backed execution environments.",
   "description_for_model": "Rexec provides cloud-based Linux sandboxes via browser. AI agents can use this service to execute code in sandboxed Docker containers, manage remote agents, and collaborate with humans in supervised sandbox sessions. Key capabilities: container lifecycle management, WebSocket terminal connections, session recording/playback, remote agent integration, and multi-user collaboration.",
   "auth": {
     "type": "user_http",

--- a/frontend/public/ai.txt
+++ b/frontend/public/ai.txt
@@ -3,7 +3,7 @@
 ## About Rexec
 
 name: Rexec
-tagline: Sandbox as a Service - Instant Linux sandboxes in your browser
+tagline: AI-Native Sandbox - Instant Linux sandboxes in your browser
 description: Rexec is a cloud-based platform that provides instant-access Linux sandboxes in the browser, powered by Docker containers. It enables collaborative development environments, remote agent support, and real-time sandbox session recording and playback.
 
 ## Core Capabilities

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Rexec - Sandbox as a Service",
+  "name": "Rexec - AI-Native Sandbox",
   "short_name": "Rexec",
   "description": "Launch secure Linux sandboxes instantly in your browser. No setup required.",
   "start_url": "/",

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,4 @@
-# Robots.txt for Rexec - Sandbox as a Service
+# Robots.txt for Rexec - AI-Native Sandbox
 
 User-agent: *
 Allow: /

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -261,7 +261,7 @@
 
     const seoConfig: Record<string, PageSEO> = {
         landing: {
-            title: "Rexec - Sandbox as a Service | Instant Linux Sandboxes",
+            title: "Rexec - AI-Native Sandbox | Instant Linux Sandboxes",
             description:
                 "Launch secure Linux sandboxes instantly in your browser. No setup required. Choose from Ubuntu, Debian, Alpine, and more. Perfect for developers, learning, and testing.",
             keywords:
@@ -273,7 +273,7 @@
                 "Experience the next generation of cloud sandboxes. Instant access to powerful Linux environments with no setup required.",
         },
         launch: {
-            title: "Rexec Launch - Sandbox as a Service | Cloud Sandboxes & Secure Agent",
+            title: "Rexec Launch - AI-Native Sandbox | Cloud Sandboxes & Secure Agent",
             description:
                 "Instant cloud sandboxes for developers. Safely run AI-generated code, access servers without SSH exposure, and spin up dev environments in seconds. Try free today.",
             keywords:
@@ -317,7 +317,7 @@
                 "resources, tutorials, videos, guides, how to, sandbox, agents, CLI",
         },
         "use-cases": {
-            title: "Use Cases - Rexec | Sandbox as a Service",
+            title: "Use Cases - Rexec | AI-Native Sandbox",
             description:
                 "Discover how developers, teams, and enterprises use Rexec for development, testing, training, and AI agent workflows.",
             keywords:
@@ -325,7 +325,7 @@
         },
         "use-case-detail": {
             title: "Use Case - Rexec",
-            description: "Detailed use case for Rexec Sandbox as a Service.",
+            description: "Detailed use case for Rexec AI-Native Sandbox.",
         },
         docs: {
             title: "Documentation - Rexec",

--- a/frontend/src/lib/components/Docs.svelte
+++ b/frontend/src/lib/components/Docs.svelte
@@ -460,7 +460,7 @@
                     <p>
                         <strong>No!</strong> Rexec is <strong>not</strong> a VM
                         or hypervisor. It's a
-                        <strong>Sandbox as a Service</strong> platform that gives
+                        <strong>AI-Native Sandbox</strong> platform that gives
                         you instant sandbox access to:
                     </p>
                     <ul>

--- a/frontend/src/lib/components/LaunchPage.svelte
+++ b/frontend/src/lib/components/LaunchPage.svelte
@@ -381,7 +381,7 @@
             <div class="footer-brand">
                 <span class="logo-icon">R</span>
                 <span>Rexec</span>
-                <span class="footer-tagline">Sandbox as a Service</span>
+                <span class="footer-tagline">AI-Native Sandbox</span>
             </div>
             <div class="footer-links">
                 <a href="/docs">Documentation</a>

--- a/frontend/src/lib/components/ResourcesPage.svelte
+++ b/frontend/src/lib/components/ResourcesPage.svelte
@@ -526,7 +526,7 @@
             href={buildCanonicalUrl(`/resources?id=${selectedResource.id}`)}
         />
     {:else}
-        <title>Tutorials | Rexec - Sandbox as a Service</title>
+        <title>Tutorials | Rexec - AI-Native Sandbox</title>
         <meta
             name="description"
             content="Learn how to use Rexec with video tutorials covering sandboxes, agents, CLI tools, and more."

--- a/frontend/src/lib/stores/terminal.ts
+++ b/frontend/src/lib/stores/terminal.ts
@@ -116,7 +116,7 @@ const REXEC_BANNER =
   "  ██╔══██╗██╔══╝   ██╔██╗ ██╔══╝  ██║\r\n" +
   "  ██║  ██║███████╗██╔╝ ██╗███████╗╚██████╗\r\n" +
   "  ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝ ╚═════╝\r\n" +
-  "\x1b[0m\x1b[38;5;243m  Sandbox as a Service · rexec.dev\x1b[0m\r\n" +
+  "\x1b[0m\x1b[38;5;243m  AI-Native Sandbox · rexec.dev\x1b[0m\r\n" +
   "\x1b[38;5;243m  Run 'rexec tools' to see available tools\x1b[0m\r\n\r\n";
 
 // Helper to handle custom key events (prevent browser defaults, map macOS keys)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
         "screenshot-mobile.png",
       ],
       manifest: {
-        name: "Rexec - Sandbox as a Service",
+        name: "Rexec - AI-Native Sandbox",
         short_name: "Rexec",
         description:
           "Launch secure Linux sandboxes instantly in your browser. No setup required.",


### PR DESCRIPTION
This is a follow-up PR to #52 to update the last few instances of 'Sandbox as a Service' in metadata, SEO tags, and the terminal welcome banner.