### PR TITLE
feat: separate console from home page

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -598,7 +598,7 @@
                     return;
                 }
 
-                currentView = "dashboard";
+                goToDashboard();
                 toast.success("Successfully signed in!");
             }
         }
@@ -652,7 +652,7 @@
                     return;
                 }
 
-                currentView = "dashboard";
+                goToDashboard();
                 containers.fetchContainers();
                 toast.success(`Welcome, ${user.name}!`);
             } else {
@@ -707,13 +707,19 @@
         const path = window.location.pathname;
         const params = new URLSearchParams(window.location.search);
 
-        // Handle root path - show dashboard if authenticated, landing if not
-        if (path === "/" || path === "") {
+        // Handle dashboard/console path
+        if (path === "/dashboard" || path === "/console") {
             if (get(isAuthenticated)) {
                 currentView = "dashboard";
             } else {
                 currentView = "landing";
             }
+            return;
+        }
+
+        // Handle root path - always show landing page now that they are separated
+        if (path === "/" || path === "") {
+            currentView = "landing";
             return;
         }
 
@@ -1253,11 +1259,11 @@
                         security.refreshFromServer();
                     });
 
-                    // Set default view to dashboard only if on root path
+                    // Set default view to landing only if on root path
                     // handleTerminalUrl() will override for specific routes like /account
                     const currentPath = window.location.pathname;
                     if (currentPath === "/" || currentPath === "") {
-                        currentView = "dashboard";
+                        currentView = "landing";
                     }
                 } else {
                     auth.logout();
@@ -1296,14 +1302,12 @@
     });
 
     // React to auth changes (only after initialization to prevent race conditions)
-    $: if (isInitialized && $isAuthenticated && currentView === "landing") {
+    $: if (isInitialized && $isAuthenticated) {
         const pendingJoin = localStorage.getItem("pendingJoinCode");
-        if (pendingJoin) {
+        if (pendingJoin && currentView === "landing") {
             localStorage.removeItem("pendingJoinCode");
             joinCode = pendingJoin;
             currentView = "join";
-        } else {
-            currentView = "dashboard";
         }
         containers.fetchContainers();
         startAutoRefresh(); // Start polling when authenticated
@@ -1338,7 +1342,17 @@
 
     // Navigation functions
     function goToDashboard() {
-        currentView = $isAuthenticated ? "dashboard" : "landing";
+        if ($isAuthenticated) {
+            currentView = "dashboard";
+            window.history.pushState({}, "", "/dashboard");
+        } else {
+            currentView = "landing";
+            window.history.pushState({}, "", "/");
+        }
+    }
+
+    function goToHome() {
+        currentView = "landing";
         window.history.pushState({}, "", "/");
     }
 
@@ -1398,7 +1412,7 @@
             window.history.pushState({}, "", "/admin");
         } else {
             toast.error("Access denied");
-            currentView = "dashboard";
+            goToDashboard();
         }
     }
 
@@ -1406,7 +1420,7 @@
         event: CustomEvent<{ id: string; name: string }>,
     ) {
         const { id, name } = event.detail;
-        currentView = "dashboard";
+        goToDashboard();
 
         // Create session - TerminalPanel will handle WebSocket connection
         void openTerminalForContainer(id, name);
@@ -1415,8 +1429,10 @@
     // Handle browser navigation
     function handlePopState() {
         const path = window.location.pathname;
-        if (path === "/" || path === "") {
+        if (path === "/dashboard" || path === "/console") {
             currentView = $isAuthenticated ? "dashboard" : "landing";
+        } else if (path === "/" || path === "") {
+            currentView = "landing";
         } else if (path === "/resources") {
             currentView = "resources";
         } else if (path === "/guides" || path === "/ai-tools") {
@@ -1676,7 +1692,9 @@
         </div>
     {:else}
         <Header
-            on:home={goToDashboard}
+            currentView={currentView}
+            on:home={goToHome}
+            on:console={goToDashboard}
             on:create={goToCreate}
             on:settings={goToSettings}
             on:sshkeys={goToSSHKeys}
@@ -1764,8 +1782,7 @@
                         ) => {
                             const { agentId, agentName } = e.detail;
                             void openTerminalForAgent(agentId, agentName);
-                            currentView = "dashboard";
-                            window.history.pushState({}, "", "/");
+                            goToDashboard();
                             toast.success(`Connecting to ${agentName}...`);
                         }}
                     />
@@ -1784,7 +1801,7 @@
                                 store?.terminal.getState().activeSessionId;
 
                             if (activeSessionId && store) {
-                                currentView = "dashboard";
+                                goToDashboard();
                                 setTimeout(() => {
                                     store.terminal.sendInput(
                                         activeSessionId,
@@ -1796,7 +1813,7 @@
                                 toast.error(
                                     "No active sandbox. Please create one first.",
                                 );
-                                currentView = "dashboard";
+                                goToDashboard();
                             }
                         }}
                     />
@@ -1978,8 +1995,7 @@
                             ) => {
                                 const { agentId, agentName } = e.detail;
                                 void openTerminalForAgent(agentId, agentName);
-                                currentView = "dashboard";
-                                window.history.pushState({}, "", "/");
+                                goToDashboard();
                                 toast.success(`Connecting to ${agentName}...`);
                                 settingsScrollSection = null;
                             }}
@@ -2011,8 +2027,7 @@
                                     store?.terminal.getState().activeSessionId;
 
                                 if (activeSessionId && store) {
-                                    currentView = "dashboard";
-                                    window.history.pushState({}, "", "/");
+                                    goToDashboard();
                                     setTimeout(() => {
                                         store.terminal.sendInput(
                                             activeSessionId,
@@ -2024,8 +2039,7 @@
                                     toast.error(
                                         "No active sandbox. Please create one first.",
                                     );
-                                    currentView = "dashboard";
-                                    window.history.pushState({}, "", "/");
+                                    goToDashboard();
                                 }
                             }}
                         />

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -13,8 +13,11 @@
     import StatusIcon from "./icons/StatusIcon.svelte";
     import InstallButton from "./InstallButton.svelte";
 
+    export let currentView = "";
+
     const dispatch = createEventDispatcher<{
         home: void;
+        console: void;
         create: void;
         settings: void;
         sshkeys: void;
@@ -260,6 +263,12 @@
     </button>
 
     <nav class="nav-links">
+        {#if $isAuthenticated && currentView !== 'dashboard'}
+            <a class="nav-link nav-link-console" href="/dashboard" onclick={(e) => { e.preventDefault(); dispatch('console'); }}>
+                <StatusIcon status="terminal" size={14} />
+                <span>Console</span>
+            </a>
+        {/if}
         <a class="nav-link" href="https://github.com/PipeOpsHQ/rexec" target="_blank" rel="noopener noreferrer">
             <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
@@ -672,7 +681,16 @@
                         dispatch("home");
                     }}
                 >
-                    <StatusIcon status="chart" size={16} /> Dashboard
+                    <StatusIcon status="home" size={16} /> Home
+                </button>
+                <button
+                    class="mobile-nav-link"
+                    onclick={() => {
+                        closeMobileMenu();
+                        dispatch("console");
+                    }}
+                >
+                    <StatusIcon status="terminal" size={16} /> Console
                 </button>
                 <div class="user-menu-divider"></div>
                 <button
@@ -871,20 +889,26 @@
         margin-left: auto;
         margin-right: 16px;
     }
+.nav-link {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 12px;
+    font-size: 12px;
+    color: var(--text-muted);
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: all 0.15s ease;
+    background: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
 
-    .nav-link {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        padding: 6px 12px;
-        font-size: 12px;
-        color: var(--text-muted);
-        text-decoration: none;
-        border: 1px solid transparent;
-        transition: all 0.15s ease;
-        background: none;
-        cursor: pointer;
-    }
+.nav-link.nav-link-console {
+    color: var(--accent);
+    border-color: var(--border);
+    background: var(--bg-elevated);
+}
 
     .nav-link:hover {
         color: var(--text);

--- a/frontend/src/lib/components/Landing.svelte
+++ b/frontend/src/lib/components/Landing.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
-    import { auth } from "$stores/auth";
+    import { auth, isAuthenticated } from "$stores/auth";
     import { toast } from "$stores/toast";
     import StatusIcon from "./icons/StatusIcon.svelte";
 
@@ -55,21 +55,27 @@
         </p>
 
         <div class="landing-actions">
-            <button class="btn btn-primary btn-lg" onclick={handleGuestClick}>
-                Launch Sandbox — Free
-            </button>
-            <button
-                class="btn btn-secondary btn-lg"
-                onclick={handleOAuthLogin}
-                disabled={isOAuthLoading}
-            >
-                {#if isOAuthLoading}
-                    <span class="btn-spinner"></span>
-                    Connecting...
-                {:else}
-                    Sign in with PipeOps
-                {/if}
-            </button>
+            {#if $isAuthenticated}
+                <button class="btn btn-primary btn-lg" onclick={() => dispatch("navigate", { view: "dashboard" })}>
+                    Go to Console
+                </button>
+            {:else}
+                <button class="btn btn-primary btn-lg" onclick={handleGuestClick}>
+                    Launch Sandbox — Free
+                </button>
+                <button
+                    class="btn btn-secondary btn-lg"
+                    onclick={handleOAuthLogin}
+                    disabled={isOAuthLoading}
+                >
+                    {#if isOAuthLoading}
+                        <span class="btn-spinner"></span>
+                        Connecting...
+                    {:else}
+                        Sign in with PipeOps
+                    {/if}
+                </button>
+            {/if}
         </div>
 
 


### PR DESCRIPTION
This separates the dashboard console from the landing page. The landing page now stays accessible at '/' even when authenticated. The dashboard is accessible at '/dashboard'. A 'Console' link was added to the header.