### PR TITLE
feat(terminal): embed AI CLIs in sandbox terminals

### DIFF
--- a/cmd/rexec/main.go
+++ b/cmd/rexec/main.go
@@ -705,6 +705,9 @@ func runServer() {
 		// Available roles/environments
 		api.GET("/roles", containerHandler.ListRoles)
 
+		// AI CLIs a terminal can auto-launch into (for the create-terminal picker)
+		api.GET("/terminal/agents", terminalHandler.ListAgentCLIs)
+
 		// Stats endpoint
 		api.GET("/stats", containerHandler.Stats)
 

--- a/frontend/src/lib/components/terminal/TerminalView.svelte
+++ b/frontend/src/lib/components/terminal/TerminalView.svelte
@@ -8,6 +8,7 @@
     } from "$stores/terminal";
     import { toast } from "$stores/toast";
     import { containers, type Container } from "$stores/containers";
+    import { api } from "$utils/api";
     import TerminalPanel from "./TerminalPanel.svelte";
     import InlineCreateTerminal from "../InlineCreateTerminal.svelte";
     import RecordingPanel from "../RecordingPanel.svelte";
@@ -157,6 +158,61 @@
     function selectExistingSession(sessionId: string) {
         terminal.setActiveSession(sessionId);
         showAddMenu = false;
+    }
+
+    // AI CLIs a terminal can auto-launch into (allowlist fetched from backend)
+    interface AgentCliOption {
+        id: string;
+        label: string;
+        description: string;
+        installHint: string;
+    }
+    let agentClis: AgentCliOption[] = [];
+
+    async function loadAgentClis() {
+        try {
+            const res = await api.get<{ agents: AgentCliOption[] }>(
+                "/api/terminal/agents",
+            );
+            agentClis = res.data?.agents ?? [];
+        } catch (e) {
+            console.error("[Terminal] Failed to load AI CLI list:", e);
+        }
+    }
+
+    // The container a new AI CLI terminal should open on: prefer the active
+    // session's container, otherwise the first available running sandbox.
+    $: agentTargetContainer = (() => {
+        if (activeId) {
+            const s = $terminal.sessions.get(activeId);
+            if (s && !s.isAgentSession) {
+                return { id: s.containerId, name: s.name };
+            }
+        }
+        const c = availableTerminals.find(
+            (t) =>
+                t.session_type !== "agent" && !t.id.startsWith("agent:"),
+        );
+        return c ? { id: c.id, name: c.name } : null;
+    })();
+
+    async function openAgentTerminal(agent: AgentCliOption) {
+        const target = agentTargetContainer;
+        if (!target) {
+            toast.error("Start or open a sandbox first");
+            return;
+        }
+        showAddMenu = false;
+        const sid = await terminal.createNewTab(
+            target.id,
+            `${agent.label}`,
+            agent.id,
+        );
+        if (!sid) {
+            toast.error(`Failed to open ${agent.label} terminal`);
+            return;
+        }
+        toast.success(`Launching ${agent.label}…`);
     }
 
     async function connectToAvailable(container: Container) {
@@ -590,6 +646,9 @@
 
     // Window event listeners
     onMount(() => {
+        // Load the AI CLI allowlist for the "Open AI CLI terminal" picker
+        void loadAgentClis();
+
         // Listen for container deletions
         window.addEventListener("container-deleted", handleContainerDeleted);
         window.addEventListener("keydown", handleGlobalKeydown);
@@ -1515,6 +1574,36 @@
                     <span>Create New Sandbox</span>
                 </button>
 
+                {#if agentClis.length > 0}
+                    <div class="add-menu-divider"></div>
+                    <div class="add-menu-label">
+                        Open AI CLI terminal
+                        {#if agentTargetContainer}
+                            <span class="add-menu-label-target"
+                                >on {agentTargetContainer.name}</span
+                            >
+                        {/if}
+                    </div>
+                    <div class="add-menu-sessions">
+                        {#each agentClis as agent}
+                            <button
+                                class="add-menu-item agent-cli-item"
+                                disabled={!agentTargetContainer}
+                                title={agentTargetContainer
+                                    ? agent.description
+                                    : "Start or open a sandbox first"}
+                                onclick={() => openAgentTerminal(agent)}
+                            >
+                                <span class="menu-icon">🤖</span>
+                                <span>{agent.label}</span>
+                                <span class="agent-cli-desc"
+                                    >{agent.description}</span
+                                >
+                            </button>
+                        {/each}
+                    </div>
+                {/if}
+
                 {#if availableTerminals.length > 0}
                     <div class="add-menu-divider"></div>
                     <div class="add-menu-label">
@@ -1684,6 +1773,33 @@
 
     .add-menu-item:hover {
         background: var(--bg-secondary);
+    }
+
+    .add-menu-item:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+    }
+
+    .add-menu-item:disabled:hover {
+        background: none;
+    }
+
+    .add-menu-item.agent-cli-item .agent-cli-desc {
+        margin-left: auto;
+        font-size: 11px;
+        color: var(--text-secondary, #888);
+        opacity: 0.8;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 45%;
+    }
+
+    .add-menu-label-target {
+        margin-left: 6px;
+        font-size: 11px;
+        color: var(--accent);
+        opacity: 0.8;
     }
 
     .add-menu-item.primary {

--- a/frontend/src/lib/stores/terminal.ts
+++ b/frontend/src/lib/stores/terminal.ts
@@ -58,6 +58,8 @@ export interface TerminalSession {
   // Agent session (external machine)
   isAgentSession: boolean;
   agentId: string | null;
+  // AI CLI to auto-launch inside the terminal (allowlisted id, e.g. "claude"); null for a plain shell
+  agentCli: string | null;
   // Collaboration mode
   isCollabSession: boolean;
   collabMode: "view" | "control" | null; // null if not a collab session
@@ -537,6 +539,7 @@ function createTerminalStore() {
     async createNewTab(
       containerId: string,
       name: string,
+      agentCli: string | null = null,
     ): Promise<string | null> {
       const authToken = get(token);
       if (!authToken) return null;
@@ -584,6 +587,7 @@ function createTerminalStore() {
         hasConnectedOnce: false,
         isAgentSession: false,
         agentId: null,
+        agentCli: agentCli,
         isCollabSession: false,
         collabMode: null,
         collabRole: null,
@@ -797,6 +801,10 @@ function createTerminalStore() {
         wsUrl = `${getWsUrl()}/ws/agent/${encodeURIComponent(agentId)}/terminal?id=${encodeURIComponent(sessionId)}`;
       } else {
         wsUrl = `${getWsUrl()}/ws/terminal/${encodeURIComponent(session.containerId)}?id=${encodeURIComponent(sessionId)}`;
+        // Auto-launch an AI CLI when this tab was created for one.
+        if (session.agentCli) {
+          wsUrl += `&agent=${encodeURIComponent(session.agentCli)}`;
+        }
       }
       const ws = createRexecWebSocket(wsUrl, authToken);
 

--- a/internal/api/handlers/terminal.go
+++ b/internal/api/handlers/terminal.go
@@ -102,6 +102,7 @@ type TerminalSession struct {
 	ForceNewSession bool   // If true, create new tmux session instead of resuming main
 	IsOwner         bool   // Container owner (vs collab participant)
 	TmuxSessionName string // Set when tmux is used ("main", "user-...", "split-...")
+	AgentCLI        string // If set (allowlisted ID), terminal auto-launches this AI CLI
 }
 
 // TerminalMessage represents messages between client and server
@@ -695,6 +696,14 @@ func (h *TerminalHandler) HandleWebSocket(c *gin.Context) {
 	// newSession=true means create a fresh tmux session instead of resuming main
 	forceNewSession := c.Query("newSession") == "true"
 
+	// Optional AI CLI to auto-launch. Validated against the allowlist so an
+	// untrusted query param can never inject a command into the container.
+	agentCLI := ""
+	if def, ok := lookupAgentCLI(c.Query("agent")); ok {
+		agentCLI = def.ID
+		log.Printf("[Terminal] AI CLI terminal requested for %s: %s", containerIdOrName, def.ID)
+	}
+
 	now := time.Now()
 	dbSessionID := uuid.New().String()
 	session := &TerminalSession{
@@ -708,6 +717,7 @@ func (h *TerminalHandler) HandleWebSocket(c *gin.Context) {
 		Done:            make(chan struct{}),
 		ForceNewSession: forceNewSession,
 		IsOwner:         isOwner,
+		AgentCLI:        agentCLI,
 	}
 
 	// Register session with unique key to allow multiplexing
@@ -993,12 +1003,17 @@ func (h *TerminalHandler) runTerminalSession(session *TerminalSession, imageType
 		// macOS containers don't use tmux (yet)
 		// Use /bin/bash directly for macOS - no detection needed
 		shell := "/bin/bash"
+		shellCmd := []string{shell, "-l"}
+		if def, ok := lookupAgentCLI(session.AgentCLI); ok {
+			// Auto-launch the AI CLI, then drop to an interactive login shell.
+			shellCmd = []string{shell, "-c", buildAgentLaunchScript(shell, def)}
+		}
 		execConfig = dockerclient.ExecCreateOptions{
 			AttachStdin:  true,
 			AttachStdout: true,
 			AttachStderr: true,
 			TTY:          true,
-			Cmd:          []string{shell, "-l"},
+			Cmd:          shellCmd,
 			Env: []string{
 				"TERM=xterm-256color",
 				"COLORTERM=truecolor",
@@ -1136,8 +1151,23 @@ func (h *TerminalHandler) runTerminalSession(session *TerminalSession, imageType
 			// Each control-mode collab user gets an independent tmux session.
 			tmuxSessionName = tmuxSessionNameForControlUser(session.UserID)
 			log.Printf("[Terminal] Control mode: using unique tmux session '%s' for user %s", tmuxSessionName, session.UserID)
+		} else if session.AgentCLI != "" {
+			// AI CLI terminals get their own persistent session, keyed by agent,
+			// so they never collide with the plain "main" shell and can resume
+			// (reconnect attaches to the running CLI instead of relaunching it).
+			tmuxSessionName = "agent-" + session.AgentCLI
+			log.Printf("[Terminal] AI CLI terminal: using tmux session '%s'", tmuxSessionName)
 		}
 		session.TmuxSessionName = tmuxSessionName
+
+		// The command tmux runs for the session. For AI CLI terminals this
+		// auto-launches the CLI and then drops to an interactive login shell;
+		// with the -A flag below, reconnects attach to the existing session so
+		// the CLI is not relaunched.
+		sessionCmd := []string{shell}
+		if def, ok := lookupAgentCLI(session.AgentCLI); ok {
+			sessionCmd = []string{shell, "-c", buildAgentLaunchScript(shell, def)}
+		}
 
 		if hasTmux {
 			// For split panes (ForceNewSession), always create new session (no -A flag)
@@ -1145,10 +1175,10 @@ func (h *TerminalHandler) runTerminalSession(session *TerminalSession, imageType
 			var tmuxCmd []string
 			if session.ForceNewSession {
 				// Create new session, don't attach to existing
-				tmuxCmd = []string{"tmux", "new-session", "-s", tmuxSessionName, shell}
+				tmuxCmd = append([]string{"tmux", "new-session", "-s", tmuxSessionName}, sessionCmd...)
 			} else {
 				// Attach if session exists, create if not
-				tmuxCmd = []string{"tmux", "new-session", "-A", "-s", tmuxSessionName, shell}
+				tmuxCmd = append([]string{"tmux", "new-session", "-A", "-s", tmuxSessionName}, sessionCmd...)
 			}
 
 			log.Printf("[Terminal] Using tmux session '%s' for %s in %s", tmuxSessionName,
@@ -1173,12 +1203,16 @@ func (h *TerminalHandler) runTerminalSession(session *TerminalSession, imageType
 		} else {
 			// Direct shell without tmux - tmux is optional, not default
 			log.Printf("[Terminal] Using direct shell (no tmux) for %s: %s", session.ContainerID[:12], shell)
+			directCmd := []string{shell, "-l"}
+			if def, ok := lookupAgentCLI(session.AgentCLI); ok {
+				directCmd = []string{shell, "-c", buildAgentLaunchScript(shell, def)}
+			}
 			execConfig = dockerclient.ExecCreateOptions{
 				AttachStdin:  true,
 				AttachStdout: true,
 				AttachStderr: true,
 				TTY:          true,
-				Cmd:          []string{shell, "-l"},
+				Cmd:          directCmd,
 				Env: []string{
 					"TERM=xterm-256color",
 					"COLORTERM=truecolor",

--- a/internal/api/handlers/terminal_agents.go
+++ b/internal/api/handlers/terminal_agents.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AgentCLI describes an AI coding CLI that a terminal can auto-launch into.
+//
+// The set of agents is a fixed allowlist: the terminal WebSocket accepts an
+// "agent" query param whose value MUST match one of these IDs. The launch
+// Command strings are hardcoded here (never derived from user input), so the
+// query param can never be used to inject arbitrary shell commands into a
+// container.
+type AgentCLI struct {
+	ID          string `json:"id"`          // stable identifier used in the ?agent= query param
+	Label       string `json:"label"`       // human-friendly name shown in the picker
+	Command     string `json:"command"`     // command invoked inside the container
+	Description string `json:"description"` // short blurb for the picker
+	InstallHint string `json:"installHint"` // shown in-terminal when the command is missing
+}
+
+// agentCLIRegistry is the allowlist of AI CLIs a terminal can boot into.
+// IDs mirror the presets already installed by the "ai"/coding container roles
+// (see internal/container/roles.go) so an embedded terminal finds them on PATH.
+var agentCLIRegistry = []AgentCLI{
+	{
+		ID:          "claude",
+		Label:       "Claude Code",
+		Command:     "claude",
+		Description: "Anthropic's Claude Code agent",
+		InstallHint: "npm install -g @anthropic-ai/claude-code",
+	},
+	{
+		ID:          "codex",
+		Label:       "Codex",
+		Command:     "codex",
+		Description: "OpenAI Codex CLI",
+		InstallHint: "npm install -g @openai/codex",
+	},
+	{
+		ID:          "gemini",
+		Label:       "Gemini CLI",
+		Command:     "gemini",
+		Description: "Google Gemini CLI",
+		InstallHint: "npm install -g @google/gemini-cli",
+	},
+	{
+		ID:          "aider",
+		Label:       "Aider",
+		Command:     "aider",
+		Description: "AI pair programming in your terminal",
+		InstallHint: "pip install aider-chat",
+	},
+	{
+		ID:          "opencode",
+		Label:       "opencode",
+		Command:     "opencode",
+		Description: "Open-source terminal coding agent",
+		InstallHint: "curl -fsSL https://opencode.ai/install | bash",
+	},
+	{
+		ID:          "amp",
+		Label:       "Sourcegraph Amp",
+		Command:     "amp",
+		Description: "Sourcegraph's agentic coding tool",
+		InstallHint: "npm install -g @sourcegraph/amp",
+	},
+}
+
+// lookupAgentCLI resolves an agent ID from the allowlist. The lookup is
+// case-insensitive and tolerant of surrounding whitespace. Returns false for
+// unknown IDs so callers can safely ignore untrusted query params.
+func lookupAgentCLI(id string) (AgentCLI, bool) {
+	id = strings.ToLower(strings.TrimSpace(id))
+	if id == "" {
+		return AgentCLI{}, false
+	}
+	for _, a := range agentCLIRegistry {
+		if a.ID == id {
+			return a, true
+		}
+	}
+	return AgentCLI{}, false
+}
+
+// buildAgentLaunchScript returns the argument for `<shell> -c` that auto-runs
+// the agent CLI and then drops the user into an interactive login shell.
+//
+// Behavior:
+//   - If the CLI is on PATH, it runs; on exit (or Ctrl-C) the user lands in a
+//     normal login shell with full scrollback preserved.
+//   - If the CLI is missing, a friendly install hint is printed instead of a
+//     bare "command not found", then the user still gets a shell.
+func buildAgentLaunchScript(shell string, def AgentCLI) string {
+	// Fall back to sh for the trailing interactive shell if none was detected.
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+	return fmt.Sprintf(
+		"if command -v %s >/dev/null 2>&1; then %s; else "+
+			"printf '\\033[33m%s is not installed in this sandbox.\\033[0m\\n'; "+
+			"printf 'Install it with: \\033[36m%s\\033[0m\\n'; fi; "+
+			"exec %s -l",
+		def.Command, def.Command, def.Label, def.InstallHint, shell,
+	)
+}
+
+// ListAgentCLIs returns the allowlist of AI CLIs the terminal can boot into.
+// The frontend uses this to populate the create-terminal picker.
+func (h *TerminalHandler) ListAgentCLIs(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"agents": agentCLIRegistry})
+}

--- a/internal/api/handlers/terminal_agents_test.go
+++ b/internal/api/handlers/terminal_agents_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLookupAgentCLI(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantID string
+		wantOK bool
+	}{
+		{"known claude", "claude", "claude", true},
+		{"case insensitive", "Claude", "claude", true},
+		{"trims whitespace", "  gemini  ", "gemini", true},
+		{"codex", "codex", "codex", true},
+		{"empty", "", "", false},
+		{"unknown", "rm-rf", "", false},
+		// Ensure the query param can't smuggle a shell command through.
+		{"injection attempt", "claude; rm -rf /", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def, ok := lookupAgentCLI(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("lookupAgentCLI(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if ok && def.ID != tt.wantID {
+				t.Fatalf("lookupAgentCLI(%q) id = %q, want %q", tt.input, def.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestBuildAgentLaunchScript(t *testing.T) {
+	def, ok := lookupAgentCLI("claude")
+	if !ok {
+		t.Fatal("expected claude to be in the allowlist")
+	}
+
+	script := buildAgentLaunchScript("/bin/bash", def)
+
+	// Must run the CLI command...
+	if !strings.Contains(script, def.Command) {
+		t.Errorf("script missing agent command %q: %s", def.Command, script)
+	}
+	// ...guard on its presence so a missing CLI shows a hint, not just an error...
+	if !strings.Contains(script, "command -v") {
+		t.Errorf("script should guard on command availability: %s", script)
+	}
+	// ...and always drop the user into an interactive login shell afterwards.
+	if !strings.Contains(script, "exec /bin/bash -l") {
+		t.Errorf("script should exec a login shell after the agent: %s", script)
+	}
+
+	// Empty shell falls back to /bin/sh so we never exec an empty command.
+	fallback := buildAgentLaunchScript("", def)
+	if !strings.Contains(fallback, "exec /bin/sh -l") {
+		t.Errorf("empty shell should fall back to /bin/sh: %s", fallback)
+	}
+}

--- a/internal/container/roles.go
+++ b/internal/container/roles.go
@@ -70,7 +70,7 @@ func AvailableRoles() []RoleInfo {
 			Name:        "Vibe Coder",
 			Description: "AI-powered coding: Copilot, Claude, aider, opencode & more.",
 			Icon:        "🤖",
-			Packages:    []string{"zsh", "git", "tmux", "python3", "python3-pip", "python3-venv", "nodejs", "npm", "curl", "wget", "htop", "vim", "neovim", "ripgrep", "fzf", "jq", "tgpt", "aichat", "mods", "aider", "opencode", "llm", "sgpt", "gh-copilot", "claude", "gemini", "zsh-autosuggestions", "zsh-syntax-highlighting"},
+			Packages:    []string{"zsh", "git", "tmux", "python3", "python3-pip", "python3-venv", "nodejs", "npm", "curl", "wget", "htop", "vim", "neovim", "ripgrep", "fzf", "jq", "tgpt", "aichat", "mods", "aider", "opencode", "codex", "amp", "llm", "sgpt", "gh-copilot", "claude", "gemini", "zsh-autosuggestions", "zsh-syntax-highlighting"},
 		},
 	}
 }
@@ -109,6 +109,8 @@ echo "[[REXEC_STATUS]]Setup complete."
 		"zsh-history-substring-search": true,
 		"aider":                        true,
 		"opencode":                     true,
+		"codex":                        true,
+		"amp":                          true,
 		"llm":                          true,
 		"sgpt":                         true,
 		"gh-copilot":                   true,
@@ -147,7 +149,7 @@ case "$1" in
         else
             export PATH="$HOME/.local/bin:/root/.local/bin:/usr/local/bin:$PATH"
             echo ""; echo "System:"; for cmd in zsh git curl wget vim nano htop jq tmux fzf ripgrep neofetch; do command -v $cmd >/dev/null 2>&1 && echo "  ✓ $cmd"; done
-            echo ""; echo "AI & Dev:"; for cmd in python3 node go rustc docker kubectl tgpt aichat mods gum aider opencode llm; do command -v $cmd >/dev/null 2>&1 && echo "  ✓ $cmd"; done
+            echo ""; echo "AI & Dev:"; for cmd in python3 node go rustc docker kubectl tgpt aichat mods gum aider opencode codex amp claude gemini llm; do command -v $cmd >/dev/null 2>&1 && echo "  ✓ $cmd"; done
             echo ""
         fi
         ;;
@@ -791,7 +793,7 @@ show_tools() {
             printf "\033[38;5;243m  (Installing AI tools...)\033[0m\n"
         fi
     fi
-    for cmd in python3 node go rustc docker kubectl tgpt aichat mods gum aider opencode llm; do
+    for cmd in python3 node go rustc docker kubectl tgpt aichat mods gum aider opencode codex amp claude gemini llm; do
         if command -v $cmd >/dev/null 2>&1; then printf "  ${GREEN}✓${NC} $cmd\n"; fi
     done
     echo ""
@@ -1166,6 +1168,42 @@ install_free_ai_tools() {
         fi
     else
         echo "    ! claude: npm not available"
+    fi
+
+    # Install Gemini CLI (requires npm)
+    echo "  Installing Gemini CLI..."
+    if command -v npm >/dev/null 2>&1; then
+        if command -v gemini >/dev/null 2>&1; then
+            echo "    ✓ gemini already installed"
+        else
+            npm install -g @google/gemini-cli 2>/dev/null && echo "    ✓ gemini installed" || echo "    ! gemini install failed"
+        fi
+    else
+        echo "    ! gemini: npm not available"
+    fi
+
+    # Install Codex CLI (requires npm)
+    echo "  Installing Codex CLI..."
+    if command -v npm >/dev/null 2>&1; then
+        if command -v codex >/dev/null 2>&1; then
+            echo "    ✓ codex already installed"
+        else
+            npm install -g @openai/codex 2>/dev/null && echo "    ✓ codex installed" || echo "    ! codex install failed"
+        fi
+    else
+        echo "    ! codex: npm not available"
+    fi
+
+    # Install Sourcegraph Amp CLI (requires npm)
+    echo "  Installing Amp CLI..."
+    if command -v npm >/dev/null 2>&1; then
+        if command -v amp >/dev/null 2>&1; then
+            echo "    ✓ amp already installed"
+        else
+            npm install -g @sourcegraph/amp 2>/dev/null && echo "    ✓ amp installed" || echo "    ! amp install failed"
+        fi
+    else
+        echo "    ! amp: npm not available"
     fi
 
     # Install aider (AI pair programming)


### PR DESCRIPTION
## Summary

Adds first-class support for **terminals that boot straight into an AI coding CLI** — the sandbox surface AgentOrc needs. Open a terminal for Claude Code, Codex, Gemini, Aider, opencode, or Amp; it auto-runs the CLI in a login shell and drops you back to that shell when the CLI exits (scrollback preserved, tmux persistence intact).

## What's included

**Backend**
- `internal/api/handlers/terminal_agents.go` (new) — an **allowlist** registry of AI CLIs (id, label, command, install hint). The `?agent=` WebSocket query param is validated against it; launch commands are hardcoded, so the param **cannot inject shell commands** into a container. Exposes `GET /api/terminal/agents` for the picker.
- `terminal.go` — parses/validates `agent`, adds `AgentCLI` to the session, and wires the launch wrapper into all three exec paths (tmux, direct-shell, macOS): `if command -v <cli>; then <cli>; else <install hint>; fi; exec <shell> -l`. AI-CLI terminals use their own tmux session (`agent-<id>`) so they never collide with the plain `main` shell and **resume instead of relaunching** on reconnect.
- `cmd/rexec/main.go` — registers `GET /api/terminal/agents`.

**Frontend (Svelte)**
- `stores/terminal.ts` — threads `agentCli` through `createNewTab` → session → the terminal WS URL (`&agent=<id>`).
- `terminal/TerminalView.svelte` — an **"Open AI CLI terminal"** section in the add-terminal menu, populated from the backend allowlist, targeting the active (or first available) sandbox; disabled with a hint when no sandbox is available.

**Provisioning**
- `internal/container/roles.go` — installs `codex`, `amp`, and the **previously-missing `gemini`** in the `overemployed` ("Vibe Coder") role, so all six picker CLIs are present on `PATH`. Provision with `image: ubuntu` + `role: overemployed` for full coverage.

## Design notes
- Launch model is **shell + auto-run** (not exec-replace): full scrollback, Ctrl-C returns to the shell. The wrapper is idempotent across reconnects because tmux `-A` attaches to the running session.
- Non-gating by design: on a sandbox without the CLI installed, the picker still works — it prints the install hint and drops to a shell rather than erroring.

## Testing
- `internal/api/handlers/terminal_agents_test.go` (new) — covers allowlist lookup (case-insensitive, whitespace-trimmed), a **shell-injection rejection** case (`claude; rm -rf /` → rejected), and the launch-script builder.
- `go build ./...` clean; `go test ./internal/api/handlers/ -run AgentCLI` and `./internal/container/ -run Role` pass.
- Frontend `tsc --noEmit` clean. (`svelte-check` couldn't run due to a pre-existing broken `@rollup/rollup-darwin-arm64` optional dep in local `node_modules`, unrelated to this change.)

## Not included
- Pre-existing uncommitted edits to `cors.go`/`security.go` are intentionally excluded — unrelated to this feature.
- `codex`/`amp` CLIs still need runtime auth (API keys/logins); this PR only ensures the binaries are on `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)