### PR TITLE
fix(admin): restore usage-over-time series on stats chart

### DIFF
--- a/frontend/src/lib/components/AdminDashboard.svelte
+++ b/frontend/src/lib/components/AdminDashboard.svelte
@@ -245,7 +245,17 @@
                         </div>
                     </div>
 
-                    {#if stats}
+                    {#if !stats}
+                        <div class="empty-state">
+                            <p>Usage stats could not be loaded.</p>
+                            {#if wsError}
+                                <p class="error-text">{wsError}</p>
+                            {/if}
+                            <button class="btn btn-secondary btn-sm" onclick={() => handleStatsRangeChange(selectedStatsRange)}>
+                                Retry
+                            </button>
+                        </div>
+                    {:else}
                         <div class="metric-grid metric-grid-primary">
                             <article class="metric-card">
                                 <span class="metric-label">Total users</span>
@@ -301,21 +311,27 @@
                             </div>
 
                             <div class="chart-wrap">
-                                <div class="stacked-chart" aria-label="Usage timeline chart">
-                                    {#each stats.timeline as point (point.bucketStart)}
-                                        {@const total = point.newUsers + point.newContainers + point.newSessions + point.newLogins + point.newAgents + point.newRecordings}
-                                        <div class="chart-bar-group" title={`${point.bucketLabel}: ${total} total events`}>
-                                            <div class="chart-bar" style={`height: ${getBarHeight(total)}`}>
-                                                <span class="bar-segment users" style={`height: ${getSegmentHeight(point.newUsers, total)}`}></span>
-                                                <span class="bar-segment containers" style={`height: ${getSegmentHeight(point.newContainers, total)}`}></span>
-                                                <span class="bar-segment sessions" style={`height: ${getSegmentHeight(point.newSessions, total)}`}></span>
-                                                <span class="bar-segment logins" style={`height: ${getSegmentHeight(point.newLogins, total)}`}></span>
-                                                <span class="bar-segment agents" style={`height: ${getSegmentHeight(point.newAgents, total)}`}></span>
-                                                <span class="bar-segment recordings" style={`height: ${getSegmentHeight(point.newRecordings, total)}`}></span>
+                                {#if !stats.timeline?.length}
+                                    <div class="chart-empty">No timeline buckets for this range.</div>
+                                {:else if chartMax <= 1 && stats.activity.newUsers === 0 && stats.activity.newContainers === 0 && stats.activity.newSessions === 0 && stats.activity.newLogins === 0 && stats.activity.newAgents === 0 && stats.activity.newRecordings === 0}
+                                    <div class="chart-empty">No usage events in this range yet.</div>
+                                {:else}
+                                    <div class="stacked-chart" aria-label="Usage timeline chart">
+                                        {#each stats.timeline as point (point.bucketStart)}
+                                            {@const total = point.newUsers + point.newContainers + point.newSessions + point.newLogins + point.newAgents + point.newRecordings}
+                                            <div class="chart-bar-group" title={`${point.bucketLabel}: ${total} total events`}>
+                                                <div class="chart-bar" style={`height: ${getBarHeight(total)}`}>
+                                                    <span class="bar-segment users" style={`height: ${getSegmentHeight(point.newUsers, total)}`}></span>
+                                                    <span class="bar-segment containers" style={`height: ${getSegmentHeight(point.newContainers, total)}`}></span>
+                                                    <span class="bar-segment sessions" style={`height: ${getSegmentHeight(point.newSessions, total)}`}></span>
+                                                    <span class="bar-segment logins" style={`height: ${getSegmentHeight(point.newLogins, total)}`}></span>
+                                                    <span class="bar-segment agents" style={`height: ${getSegmentHeight(point.newAgents, total)}`}></span>
+                                                    <span class="bar-segment recordings" style={`height: ${getSegmentHeight(point.newRecordings, total)}`}></span>
+                                                </div>
                                             </div>
-                                        </div>
-                                    {/each}
-                                </div>
+                                        {/each}
+                                    </div>
+                                {/if}
                             </div>
 
                             <div class="chart-axis">
@@ -878,6 +894,34 @@
             linear-gradient(to top, transparent 24%, color-mix(in srgb, var(--border) 70%, transparent) 25%, transparent 26%),
             linear-gradient(to top, transparent 49%, color-mix(in srgb, var(--border) 70%, transparent) 50%, transparent 51%),
             linear-gradient(to top, transparent 74%, color-mix(in srgb, var(--border) 70%, transparent) 75%, transparent 76%);
+    }
+
+    .chart-empty,
+    .empty-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        min-height: 160px;
+        color: var(--text-muted);
+        font-size: 13px;
+        text-align: center;
+    }
+
+    .empty-state {
+        border: 1px dashed var(--border);
+        border-radius: 12px;
+        padding: 24px;
+        background: var(--bg-secondary);
+    }
+
+    .error-text {
+        color: var(--error, #f87171);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        word-break: break-word;
+        max-width: 480px;
     }
 
     .stacked-chart {

--- a/internal/api/handlers/admin.go
+++ b/internal/api/handlers/admin.go
@@ -161,7 +161,10 @@ func (h *AdminHandler) UsageStats(c *gin.Context) {
 
 	stats, err := h.store.GetAdminUsageStats(c.Request.Context(), from, to, interval)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch usage stats"})
+		// Surface the real failure in logs — a missing table or SQL mismatch
+		// previously left the "Usage over time" chart empty with only a generic 500.
+		c.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch usage stats", "detail": err.Error()})
 		return
 	}
 

--- a/internal/storage/postgres_admin.go
+++ b/internal/storage/postgres_admin.go
@@ -292,8 +292,10 @@ func buildAdminUsageBuckets(from, to time.Time, interval string) ([]models.Admin
 	}
 
 	buckets := make([]models.AdminUsagePoint, 0)
-	cursor := from
-	for cursor.Before(to) {
+	// Normalize to UTC so bucket keys match SQL date_trunc(... AT TIME ZONE 'UTC').
+	cursor := from.UTC()
+	end := to.UTC()
+	for cursor.Before(end) {
 		next := cursor.Add(step)
 		if interval == "month" {
 			next = cursor.AddDate(0, 1, 0)
@@ -311,8 +313,8 @@ func buildAdminUsageBuckets(from, to time.Time, interval string) ([]models.Admin
 
 	if len(buckets) == 0 {
 		buckets = append(buckets, models.AdminUsagePoint{
-			BucketStart: from,
-			BucketLabel: from.Format("Jan 2"),
+			BucketStart: from.UTC(),
+			BucketLabel: from.UTC().Format("Jan 2"),
 		})
 	}
 
@@ -324,35 +326,47 @@ func (s *PostgresStore) fillAdminUsageSeries(ctx context.Context, timeline []mod
 		return nil
 	}
 
+	// Return epoch seconds so assignment never depends on time.Time map-key
+	// equality (lib/pq often scans timestamptz with a non-UTC Location, which
+	// makes Go map lookups miss even when Equal() is true — leaving the chart
+	// all zeros while totals still look fine).
 	query := fmt.Sprintf(`
-		SELECT date_trunc('%s', %s AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket, COUNT(*)
+		SELECT EXTRACT(EPOCH FROM date_trunc('%s', %s AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::bigint AS bucket_unix,
+		       COUNT(*)::int
 		FROM %s
 		WHERE %s >= $1 AND %s < $2
 		GROUP BY 1
 		ORDER BY 1
 	`, interval, column, table, column, column)
 
-	rows, err := s.db.QueryContext(ctx, query, from, to)
+	rows, err := s.db.QueryContext(ctx, query, from.UTC(), to.UTC())
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 
-	points := make(map[time.Time]*models.AdminUsagePoint, len(timeline))
-	for i := range timeline {
-		points[timeline[i].BucketStart] = &timeline[i]
-	}
+	points := indexAdminUsageTimeline(timeline)
 
 	for rows.Next() {
-		var bucket time.Time
+		var bucketUnix int64
 		var count int
-		if err := rows.Scan(&bucket, &count); err != nil {
+		if err := rows.Scan(&bucketUnix, &count); err != nil {
 			return err
 		}
-		if point, ok := points[bucket]; ok {
+		if point, ok := points[bucketUnix]; ok {
 			assign(point, count)
 		}
 	}
 
 	return rows.Err()
+}
+
+// indexAdminUsageTimeline maps each bucket's UTC unix second to the point so
+// SQL series rows can be merged without time.Location mismatches.
+func indexAdminUsageTimeline(timeline []models.AdminUsagePoint) map[int64]*models.AdminUsagePoint {
+	points := make(map[int64]*models.AdminUsagePoint, len(timeline))
+	for i := range timeline {
+		points[timeline[i].BucketStart.UTC().Unix()] = &timeline[i]
+	}
+	return points
 }

--- a/internal/storage/postgres_admin_usage_test.go
+++ b/internal/storage/postgres_admin_usage_test.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rexec/rexec/internal/models"
+)
+
+func TestBuildAdminUsageBucketsDay(t *testing.T) {
+	from := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+
+	buckets, err := buildAdminUsageBuckets(from, to, "day")
+	if err != nil {
+		t.Fatalf("buildAdminUsageBuckets: %v", err)
+	}
+	if len(buckets) != 3 {
+		t.Fatalf("expected 3 day buckets, got %d", len(buckets))
+	}
+	if !buckets[0].BucketStart.Equal(from) {
+		t.Fatalf("first bucket start = %v, want %v", buckets[0].BucketStart, from)
+	}
+	if buckets[0].BucketStart.Location() != time.UTC {
+		t.Fatalf("bucket location = %v, want UTC", buckets[0].BucketStart.Location())
+	}
+}
+
+func TestBuildAdminUsageBucketsMonth(t *testing.T) {
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	buckets, err := buildAdminUsageBuckets(from, to, "month")
+	if err != nil {
+		t.Fatalf("buildAdminUsageBuckets: %v", err)
+	}
+	if len(buckets) != 3 {
+		t.Fatalf("expected 3 month buckets, got %d (%v)", len(buckets), buckets)
+	}
+	if buckets[1].BucketStart.Month() != time.February {
+		t.Fatalf("second bucket month = %v, want February", buckets[1].BucketStart.Month())
+	}
+}
+
+func TestIndexAdminUsageTimelineMatchesDriverLocations(t *testing.T) {
+	// Reproduces the production bug: SQL buckets scanned by lib/pq often have a
+	// different *time.Location than Go-built UTC buckets, so map[time.Time]
+	// lookups miss even when the instants are Equal.
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	timeline := []models.AdminUsagePoint{
+		{BucketStart: start, BucketLabel: "Aug 1"},
+		{BucketStart: start.Add(24 * time.Hour), BucketLabel: "Aug 2"},
+	}
+	index := indexAdminUsageTimeline(timeline)
+
+	// Same wall clock, empty location offset 0 — common after some drivers.
+	driverBucket := time.Date(2026, 8, 1, 0, 0, 0, 0, time.FixedZone("", 0))
+	if !driverBucket.Equal(start) {
+		t.Fatal("test setup: driver bucket should Equal start")
+	}
+	if _, ok := map[time.Time]struct{}{start: {}}[driverBucket]; ok {
+		t.Fatal("expected time.Time map key mismatch for FixedZone(\"\", 0) vs UTC")
+	}
+
+	point, ok := index[driverBucket.UTC().Unix()]
+	if !ok || point == nil {
+		t.Fatalf("unix index miss for driver bucket %v", driverBucket)
+	}
+	if point.BucketLabel != "Aug 1" {
+		t.Fatalf("assigned wrong point: %q", point.BucketLabel)
+	}
+
+	// Local-zone equivalent instant should also hit via Unix seconds.
+	localEq := start.In(time.Local)
+	if _, ok := index[localEq.UTC().Unix()]; !ok {
+		t.Fatalf("unix index miss for local equivalent %v", localEq)
+	}
+}
+
+func TestAssignSeriesViaUnixIndex(t *testing.T) {
+	from := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	timeline := []models.AdminUsagePoint{
+		{BucketStart: from},
+		{BucketStart: from.Add(24 * time.Hour)},
+	}
+	index := indexAdminUsageTimeline(timeline)
+
+	// Simulate two SQL rows with non-UTC locations.
+	rows := []struct {
+		bucket time.Time
+		count  int
+	}{
+		{time.Date(2026, 8, 1, 0, 0, 0, 0, time.FixedZone("UTC", 0)), 5},
+		{from.Add(24 * time.Hour).In(time.Local), 3},
+	}
+
+	for _, row := range rows {
+		if point, ok := index[row.bucket.UTC().Unix()]; ok {
+			point.NewUsers = row.count
+		}
+	}
+
+	if timeline[0].NewUsers != 5 {
+		t.Fatalf("day0 users = %d, want 5", timeline[0].NewUsers)
+	}
+	if timeline[1].NewUsers != 3 {
+		t.Fatalf("day1 users = %d, want 3", timeline[1].NewUsers)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix admin **Usage over time** chart/table showing all zeros while metric totals still looked correct.
- Root cause: series rows were merged with `map[time.Time]`. lib/pq often returns timestamptz values with a non-UTC `Location`, so map lookups missed even when `Equal()` was true.
- Match buckets by **UTC unix seconds** from `EXTRACT(EPOCH FROM date_trunc(...))` instead of `time.Time` map keys.
- Add unit tests covering the location mismatch, and improve empty/error UI for the stats panel.

## Test plan
- [x] `go test ./internal/storage/ -run 'AdminUsage|IndexAdmin|AssignSeries|BuildAdmin'`
- [ ] Deploy / run API, open Admin → Stats
- [ ] Confirm range toggles (24H/7D/30D/90D/12M) populate the stacked chart and table with non-zero rows when activity exists
- [ ] Confirm totals cards still match DB activity counts
- [ ] Export CSV and verify period columns align with the chart