### PR TITLE
ci(php): Packagist registration helpers

### DIFF
--- a/.github/workflows/packagist-update.yml
+++ b/.github/workflows/packagist-update.yml
@@ -1,0 +1,60 @@
+name: Packagist update
+
+# After the package is submitted once on Packagist, this pings Packagist to
+# re-crawl when PHP SDK tags/sync land. Requires PACKAGIST_USERNAME + PACKAGIST_TOKEN.
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Sync PHP SDK", "Publish SDKs"]
+    types: [completed]
+  push:
+    branches: [main]
+    paths:
+      - 'sdk/php/**'
+      - '.github/workflows/packagist-update.yml'
+      - '.github/workflows/sync-php-sdk.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    # Only when Packagist secrets exist
+    steps:
+      - name: Check secrets
+        id: secrets
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+        run: |
+          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_TOKEN:-}" ]; then
+            echo "configured=false" >> $GITHUB_OUTPUT
+            echo "::notice::PACKAGIST_USERNAME/TOKEN not set — skip auto-update"
+            echo "Submit once: https://packagist.org/packages/submit"
+            echo "Repo URL: https://github.com/PipeOpsHQ/rexec-php"
+          else
+            echo "configured=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create package if missing
+        if: steps.secrets.outputs.configured == 'true'
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+        run: |
+          set -euo pipefail
+          AUTH="username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}"
+          # create-package is idempotent-ish; ignore already-exists failures
+          curl -sS -X POST \
+            -H 'Content-Type: application/json' \
+            "https://packagist.org/api/create-package?${AUTH}" \
+            -d '{"repository":{"url":"https://github.com/PipeOpsHQ/rexec-php"}}' \
+            || true
+          curl -sS -X POST \
+            -H 'Content-Type: application/json' \
+            "https://packagist.org/api/update-package?${AUTH}" \
+            -d '{"repository":{"url":"https://github.com/PipeOpsHQ/rexec-php"}}'
+          echo
+          curl -sS -o /dev/null -w "packagist HTTP %{http_code}\n" \
+            "https://packagist.org/packages/pipeopshq/rexec.json"

--- a/scripts/register-packagist.sh
+++ b/scripts/register-packagist.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Register / update pipeopshq/rexec on Packagist via API.
+#
+# Prerequisites (one-time, from https://packagist.org/profile/):
+#   export PACKAGIST_USERNAME=your-username
+#   export PACKAGIST_TOKEN=your-api-token
+#
+# Usage:
+#   ./scripts/register-packagist.sh              # create package if missing
+#   ./scripts/register-packagist.sh --update      # force update/crawl
+set -euo pipefail
+
+REPO_URL="${PACKAGIST_REPO_URL:-https://github.com/PipeOpsHQ/rexec-php}"
+PACKAGE="${PACKAGIST_PACKAGE:-pipeopshq/rexec}"
+
+if [[ -z "${PACKAGIST_USERNAME:-}" || -z "${PACKAGIST_TOKEN:-}" ]]; then
+  echo "Set PACKAGIST_USERNAME and PACKAGIST_TOKEN from https://packagist.org/profile/"
+  echo "Then re-run: $0"
+  exit 1
+fi
+
+AUTH="username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}"
+
+create_package() {
+  echo "Creating Packagist package from ${REPO_URL}..."
+  RESP=$(curl -sS -X POST \
+    -H 'Content-Type: application/json' \
+    "https://packagist.org/api/create-package?${AUTH}" \
+    -d "{\"repository\":{\"url\":\"${REPO_URL}\"}}")
+  echo "$RESP"
+  echo "$RESP" | grep -qi 'success\|already' && return 0
+  # "Package already exists" is fine
+  if echo "$RESP" | grep -qi 'already exists\|Package exists'; then
+    echo "Package already registered."
+    return 0
+  fi
+  return 1
+}
+
+update_package() {
+  echo "Triggering Packagist update for ${PACKAGE}..."
+  RESP=$(curl -sS -X POST \
+    -H 'Content-Type: application/json' \
+    "https://packagist.org/api/update-package?${AUTH}" \
+    -d "{\"repository\":{\"url\":\"${REPO_URL}\"}}")
+  echo "$RESP"
+}
+
+if [[ "${1:-}" == "--update" ]]; then
+  update_package
+else
+  create_package || update_package
+fi
+
+echo
+echo "Verify: https://packagist.org/packages/${PACKAGE}"
+curl -sS -o /dev/null -w "packagist HTTP %{http_code}\n" "https://packagist.org/packages/${PACKAGE}.json"

--- a/sdk/php/composer.json
+++ b/sdk/php/composer.json
@@ -3,12 +3,11 @@
     "description": "Official PHP SDK for Rexec — AI-Native Sandbox API",
     "type": "library",
     "license": "MIT",
-    "version": "1.0.1",
     "keywords": ["rexec", "terminal", "sandbox", "container", "docker", "devtools", "pipeops"],
-    "homepage": "https://github.com/PipeOpsHQ/rexec",
+    "homepage": "https://github.com/PipeOpsHQ/rexec-php",
     "support": {
-        "issues": "https://github.com/PipeOpsHQ/rexec/issues",
-        "source": "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/php"
+        "issues": "https://github.com/PipeOpsHQ/Rexec/issues",
+        "source": "https://github.com/PipeOpsHQ/rexec-php"
     },
     "authors": [
         {
@@ -39,3 +38,4 @@
     },
     "minimum-stability": "stable"
 }
+


### PR DESCRIPTION
## Summary
- Prep for Packagist: `composer.json` uses git tags for versions, homepage points at `PipeOpsHQ/rexec-php`
- `scripts/register-packagist.sh` + `packagist-update` workflow for API create/update when `PACKAGIST_USERNAME`/`PACKAGIST_TOKEN` are set
- Dedicated package repo already has `v1.0.1` and is installable via VCS

## One-time Packagist submit
1. Sign in at https://packagist.org/login/github
2. Submit https://github.com/PipeOpsHQ/rexec-php at https://packagist.org/packages/submit
3. Optional: add API token secrets for auto-updates