### PR TITLE
docs(sdk): Quick Start & API Reference for all official clients

### DIFF
--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -1,68 +1,276 @@
-# Rexec SDK Documentation
+# Rexec SDK — API Reference
 
 Official client libraries for the Rexec API (sandboxes, files, and terminals).
 
-> **Verified E2E** against a live Rexec instance (`list` → `create` → `get` → `delete`).  
-> Source smoke tests: [`scripts/sdk-e2e/`](../scripts/sdk-e2e/).
+**Product:** Rexec is an AI-native sandbox platform — instant, isolated Linux environments (containers) via API / UI / CLI. SDKs share one REST + WebSocket surface.
+
+| | |
+|--|--|
+| **Hosted base URL** | `https://rexec.sh` |
+| **Auth header** | `Authorization: Bearer <token>` |
+| **SDK version** | **v1.0.1** |
+| **Quick start** | [SDK_GETTING_STARTED.md](SDK_GETTING_STARTED.md) |
+| **Publishing** | [SDK_PUBLISHING.md](SDK_PUBLISHING.md) |
+| **Source monorepo** | [github.com/PipeOpsHQ/Rexec](https://github.com/PipeOpsHQ/Rexec) (`sdk/{js,python,go,rust,ruby,dotnet,java,php}`) |
+| **In-app docs** | `/docs/sdk` on the product UI |
+| **E2E smoke** | [`scripts/sdk-e2e/`](../scripts/sdk-e2e/) (`test-js.mjs`, `test_py.py`, Go/Rust/Ruby/.NET/Java/PHP runners) |
+
+> **Verified E2E** against a live Rexec instance: `list` → `create` → `get` → `delete`.
+
+---
 
 ## Available SDKs (v1.0.1)
 
-| Language | Package | Install |
-|----------|---------|---------|
-| **JavaScript / TypeScript** | [pipeops-rexec](https://www.npmjs.com/package/pipeops-rexec) | `npm install pipeops-rexec` |
-| **Python** | [pipeops-rexec](https://pypi.org/project/pipeops-rexec/) | `pip install pipeops-rexec` |
-| **Go** | [github.com/PipeOpsHQ/rexec-go](https://github.com/PipeOpsHQ/rexec-go) | `go get github.com/PipeOpsHQ/rexec-go@v1.0.1` |
-| **Rust** | [pipeops-rexec](https://crates.io/crates/pipeops-rexec) | `cargo add pipeops-rexec` |
-| **Ruby** | [pipeops-rexec](https://rubygems.org/gems/pipeops-rexec) | `gem install pipeops-rexec` |
-| **C# / .NET** | [PipeOps.Rexec](https://www.nuget.org/packages/PipeOps.Rexec) | `dotnet add package PipeOps.Rexec` |
-| **Java / Kotlin** | `io.pipeops:rexec` | Maven/Gradle (source in repo; Maven Central when secrets set) |
-| **PHP** | [pipeopshq/rexec](https://packagist.org/packages/pipeopshq/rexec) | `composer require pipeopshq/rexec` |
+| Language | Package / module | Install | Import notes |
+|----------|------------------|---------|--------------|
+| **JS / TS** | [pipeops-rexec](https://www.npmjs.com/package/pipeops-rexec) | `npm install pipeops-rexec` | `import { RexecClient } from 'pipeops-rexec'` |
+| **Python** | [pipeops-rexec](https://pypi.org/project/pipeops-rexec/) | `pip install pipeops-rexec` | `from rexec import RexecClient` |
+| **Go** | [github.com/PipeOpsHQ/rexec-go](https://github.com/PipeOpsHQ/rexec-go) | `go get github.com/PipeOpsHQ/rexec-go@v1.0.1` | `import rexec "github.com/PipeOpsHQ/rexec-go"` |
+| **Rust** | [pipeops-rexec](https://crates.io/crates/pipeops-rexec) | `cargo add pipeops-rexec` | `use rexec::{…}` (crate name ≠ import name) |
+| **Ruby** | [pipeops-rexec](https://rubygems.org/gems/pipeops-rexec) | `gem install pipeops-rexec` | `require "rexec"` |
+| **C# / .NET** | [PipeOps.Rexec](https://www.nuget.org/packages/PipeOps.Rexec) | `dotnet add package PipeOps.Rexec` | `using Rexec;` |
+| **Java / Kotlin** | `io.pipeops:rexec:1.0.1` | Maven/Gradle | `import io.pipeops.rexec.*` |
+| **PHP** | [pipeopshq/rexec](https://packagist.org/packages/pipeopshq/rexec) | `composer require pipeopshq/rexec` | `use Rexec\RexecClient` |
 
 Publishing is **GitHub Actions only** — see [SDK_PUBLISHING.md](SDK_PUBLISHING.md).
 
-## Auth
-
-1. Open your Rexec UI → **Settings** → **API Tokens** → generate a token  
-2. Or use guest login for short-lived tests:
+### Fallback installs
 
 ```bash
-export REXEC_URL=https://rexec.sh   # or your instance
+# PHP (if Packagist 404) — VCS from standalone mirror
+composer config repositories.rexec-php vcs https://github.com/PipeOpsHQ/rexec-php
+composer require pipeopshq/rexec:^1.0
+
+# Java from monorepo until Maven Central is configured
+cd sdk/java && mvn install -DskipTests
+```
+
+---
+
+## Auth
+
+### 1. API token (recommended)
+
+Rexec UI → **Settings** → **API Tokens** → create token. Use for production apps and agents.
+
+### 2. Guest JWT (smoke tests)
+
+```bash
+export REXEC_URL=https://rexec.sh
 export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \
   -H 'Content-Type: application/json' \
   -d '{"username":"sdk_demo","email":"you@example.com"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
 ```
 
-Use the token as `Authorization: Bearer <token>` (all SDKs set this for you).
+SDKs set `Authorization: Bearer <token>` on REST and (where applicable) WebSocket upgrades.
 
-## Images
-
-Hosted Rexec accepts **image aliases**, not arbitrary Docker Hub tags:
-
-- Prefer: `ubuntu`, `ubuntu-24`, `debian`, `alpine`, `fedora`, …
-- Avoid: `ubuntu:24.04` (may return `unsupported image type`)
-
-List aliases with `GET /api/images` on your instance.
-
-## Common API surface
-
-Every SDK wraps the same REST resources:
-
-| Operation | HTTP |
-|-----------|------|
-| List sandboxes | `GET /api/containers` → `{ containers: [...], count, limit }` |
-| Create | `POST /api/containers` `{ image, name? }` (often async `status: creating`) |
-| Get | `GET /api/containers/:id` |
-| Start / stop | `POST .../start` · `POST .../stop` |
-| Delete | `DELETE /api/containers/:id` |
-| Files list | `GET /api/containers/:id/files/list?path=` |
-| Terminal | WebSocket `/ws/terminal/:id` |
-
-There is **no** high-level `exec()` helper in the published SDKs; run commands via the terminal WebSocket (or your own HTTP tooling).
+Guest accounts have **limited** concurrent sandboxes and session lifetime; do not use for production.
 
 ---
 
-## JavaScript / TypeScript
+## Image aliases
+
+Hosted Rexec rejects many raw Docker Hub tags.
+
+| Prefer (aliases) | Avoid on hosted |
+|------------------|-----------------|
+| `ubuntu`, `ubuntu-24`, `ubuntu-22` | `ubuntu:24.04`, `ubuntu:latest` |
+| `debian`, `alpine`, `fedora`, `archlinux`, … | Arbitrary Hub digests/tags |
+
+Catalog: **`GET /api/images`**.
+
+---
+
+## Shared API surface
+
+Every SDK exposes roughly three services over the same HTTP/WS endpoints.
+
+### Containers / sandboxes
+
+| Method | HTTP | Notes |
+|--------|------|--------|
+| **List** | `GET /api/containers` | Response is often `{ containers: [...] \| null, count, limit }`. SDKs **normalize to an array**. |
+| **Create** | `POST /api/containers` body `{ image, name? }` | Often returns immediately with `status: "creating"` (**async create**). |
+| **Get** | `GET /api/containers/:id` | Poll until `status === "running"` if you need a ready shell. |
+| **Start** | `POST /api/containers/:id/start` | |
+| **Stop** | `POST /api/containers/:id/stop` | |
+| **Delete** | `DELETE /api/containers/:id` | |
+
+### Files (per container)
+
+| Method | HTTP |
+|--------|------|
+| **List dir** | `GET /api/containers/:id/files/list?path=` |
+| **Read** | `GET /api/containers/:id/files?path=` |
+| **Write** | `POST /api/containers/:id/files` (content often base64) |
+| **Mkdir** | `POST /api/containers/:id/files/mkdir` (JS+; check language README) |
+| **Delete** | `DELETE /api/containers/:id/files?path=` |
+
+### Terminal
+
+| Method | Transport |
+|--------|-----------|
+| **Connect** | WebSocket `wss://<host>/ws/terminal/:id?cols=&rows=` with Bearer auth |
+| **write / onData / resize / close** | SDK helpers over the socket |
+
+### Explicit non-features
+
+- **No first-class `exec()` HTTP API** on hosted Rexec. Do not treat `exec` as the primary way to run commands. Use the **terminal WebSocket** (or raw HTTP if you build your own client).
+- **Create is often async** — poll `get()` until `running` when you need a ready PTY.
+- **Hosted images use aliases**, not arbitrary Docker Hub tags.
+
+---
+
+## Client construction
+
+| Lang | Construct | Containers |
+|------|-----------|------------|
+| **JS** | `new RexecClient({ baseURL, token })` | `client.containers.list()` / `.create({ image, name? })` |
+| **Python** | `async with RexecClient(url, token)` | `await client.containers.list()` / `.create(image=…, name=…)` |
+| **Go** | `rexec.NewClient(url, token)` | `client.Containers.List(ctx)` / `.Create(ctx, &CreateContainerRequest{…})` |
+| **Rust** | `RexecClient::new(url, token)` | `client.containers().list().await` / `.create(CreateContainerRequest::new("ubuntu").name(…))` |
+| **Ruby** | `Rexec::Client.new(url, token)` | `client.containers.list` / `.create(image: "ubuntu", name: "demo")` |
+| **.NET** | `new RexecClient(url, token)` | `await client.Containers.ListAsync()` / `CreateAsync(new CreateContainerRequest("ubuntu") { Name = … })` |
+| **Java** | `new RexecClient(url, token)` | `client.containers().list()` / `.create(new CreateContainerRequest("ubuntu").setName(…))` |
+| **PHP** | `new Rexec\RexecClient($url, $token)` | `$client->containers()->list()` / `->create('ubuntu', ['name' => 'demo'])` |
+
+Optional client options (language-dependent): custom `fetch` (JS), timeouts, TLS. Defaults point at your `baseURL` + Bearer token.
+
+---
+
+## Container model
+
+Conceptual fields (names may be camelCase or snake_case per language):
+
+| Field | Description |
+|-------|-------------|
+| `id` | Sandbox id |
+| `name` | Display name |
+| `image` | Alias used at create |
+| `status` | `"creating"` \| `"running"` \| `"stopped"` \| `"error"` (and similar) |
+| `created_at` | Create time |
+| `started_at` | Optional |
+| `labels` | Optional map |
+| `environment` | Optional map |
+
+### Status lifecycle
+
+```
+create → creating → running ⇄ stopped → (delete)
+                 ↘ error
+```
+
+### List payload quirks
+
+Raw API:
+
+```json
+{ "containers": [ /* or null */ ], "count": 0, "limit": 1 }
+```
+
+SDKs return a plain array so callers never special-case `null`.
+
+---
+
+## Containers API (detail)
+
+Happy path for every language:
+
+1. `list()`
+2. `create({ image: "ubuntu", name?: "…" })`
+3. `get(id)` — optionally loop until `status == "running"`
+4. `delete(id)`
+
+Also available: `start(id)`, `stop(id)`.
+
+### Optional: wait until running (pattern)
+
+```typescript
+async function waitRunning(client: RexecClient, id: string, ms = 60_000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    const c = await client.containers.get(id);
+    if (c.status === 'running') return c;
+    if (c.status === 'error') throw new Error('sandbox failed');
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error('timeout waiting for running');
+}
+```
+
+---
+
+## Files API (detail)
+
+Typical flow after the sandbox is `running`:
+
+```typescript
+// JS
+const entries = await client.files.list(containerId, '/home');
+const bytes = await client.files.read(containerId, '/etc/hostname');
+await client.files.write(containerId, '/tmp/hello.txt', 'hi\n');
+await client.files.mkdir?.(containerId, '/tmp/work'); // if available
+await client.files.delete(containerId, '/tmp/hello.txt');
+```
+
+Write payloads may be base64-encoded depending on language bindings; SDKs accept strings/bytes and encode as needed.
+
+---
+
+## Terminal WebSocket {#terminal-websocket}
+
+### Connect
+
+```
+wss://<host>/ws/terminal/<container_id>?cols=80&rows=24
+```
+
+Auth: Bearer token (query or header depending on environment; SDKs handle this).
+
+### SDK helpers (common)
+
+| Helper | Purpose |
+|--------|---------|
+| `write(data)` | Send keystrokes / shell input (often UTF-8 text or bytes) |
+| `onData(cb)` | Receive PTY output |
+| `resize(cols, rows)` | Often sends JSON `{ "type": "resize", "cols", "rows" }` on the socket |
+| `close()` | Tear down the WebSocket |
+
+### Example (JS)
+
+```typescript
+const term = await client.terminal.connect(container.id, { cols: 120, rows: 40 });
+term.onData((data) => process.stdout.write(String(data)));
+term.write('echo hello from rexec\n');
+term.resize(100, 30);
+term.close();
+```
+
+Do **not** document a primary `exec()` RPC for hosted Rexec; interactive and one-shot commands go through this socket (or your own HTTP client if you implement one).
+
+---
+
+## Errors
+
+| SDK | Exception / error type |
+|-----|------------------------|
+| JS | `RexecError` (`statusCode`, `message`) |
+| Python | `RexecAPIError`, `RexecConnectionError` |
+| Go | `*rexec.APIError` |
+| Rust | `rexec::Error` |
+| Ruby | `Rexec::APIError` |
+| .NET | `RexecException` |
+| Java | `RexecException` |
+| PHP | `RexecException` |
+
+HTTP 4xx/5xx from the API map into these types. Network failures may use a separate connection error (Python).
+
+---
+
+## Language examples
+
+### JavaScript / TypeScript
 
 ```bash
 npm install pipeops-rexec
@@ -88,13 +296,14 @@ const got = await client.containers.get(container.id);
 await client.containers.delete(container.id);
 
 // Terminal (browser WebSocket or `ws` in Node)
+// Prefer after status === "running"
 const term = await client.terminal.connect(container.id);
 term.onData((data) => process.stdout.write(String(data)));
 term.write('echo hello\n');
 term.close();
 ```
 
-## Python
+### Python
 
 ```bash
 pip install pipeops-rexec
@@ -116,7 +325,7 @@ async def main():
 asyncio.run(main())
 ```
 
-## Go
+### Go
 
 ```bash
 go get github.com/PipeOpsHQ/rexec-go@v1.0.1
@@ -153,7 +362,9 @@ func main() {
 }
 ```
 
-## Rust
+Standalone module repo: [PipeOpsHQ/rexec-go](https://github.com/PipeOpsHQ/rexec-go) (synced from monorepo `sdk/go`).
+
+### Rust
 
 ```bash
 cargo add pipeops-rexec tokio --features tokio/full
@@ -185,7 +396,7 @@ async fn main() -> Result<(), rexec::Error> {
 
 Import crate name: `use rexec::...` (package name is `pipeops-rexec`).
 
-## Ruby
+### Ruby
 
 ```bash
 gem install pipeops-rexec   # Ruby >= 3.0
@@ -203,7 +414,7 @@ client.containers.get(c.id)
 client.containers.delete(c.id)
 ```
 
-## C# / .NET
+### C# / .NET
 
 ```bash
 dotnet add package PipeOps.Rexec
@@ -223,9 +434,10 @@ var c = await client.Containers.CreateAsync(new CreateContainerRequest("ubuntu")
 Console.WriteLine($"{c?.Id} {c?.Status}");
 await client.Containers.GetAsync(c!.Id);
 await client.Containers.DeleteAsync(c.Id);
+// Run commands via Terminal WebSocket helpers — not a primary HTTP exec() API.
 ```
 
-## Java / Kotlin
+### Java / Kotlin
 
 ```xml
 <dependency>
@@ -250,7 +462,7 @@ client.containers().get(c.getId());
 client.containers().delete(c.getId());
 ```
 
-Kotlin can use the same JAR:
+Kotlin:
 
 ```kotlin
 val client = RexecClient(System.getenv("REXEC_URL"), System.getenv("REXEC_TOKEN"))
@@ -258,17 +470,17 @@ val c = client.containers().create(CreateContainerRequest("ubuntu").setName("dem
 client.containers().delete(c.id)
 ```
 
-Install from source until Maven Central is configured: `cd sdk/java && mvn install -DskipTests`.  
-Publish guide: [SDK_PUBLISHING.md](SDK_PUBLISHING.md#maven-central-java--sonatype-central-publisher-portal).
+Install from source: `cd sdk/java && mvn install -DskipTests`.  
+Maven Central coordinates: `io.pipeops:rexec:1.0.1` · [repo path](https://repo1.maven.org/maven2/io/pipeops/rexec/).
 
-## PHP
+### PHP
 
 ```bash
 composer require pipeopshq/rexec
 ```
 
-Canonical Packagist repo: [PipeOpsHQ/rexec-php](https://github.com/PipeOpsHQ/rexec-php) (synced from `sdk/php`).  
-If Packagist is not linked yet, install from VCS:
+Canonical Packagist source: [PipeOpsHQ/rexec-php](https://github.com/PipeOpsHQ/rexec-php) (synced from `sdk/php`).  
+If Packagist is not linked yet:
 
 ```bash
 composer config repositories.rexec-php vcs https://github.com/PipeOpsHQ/rexec-php
@@ -290,30 +502,33 @@ $client->containers()->get($c->id);
 $client->containers()->delete($c->id);
 ```
 
-Packagist syncs from GitHub once the package is submitted (see [SDK_PUBLISHING.md](SDK_PUBLISHING.md)).
-
-## Error handling
-
-| SDK | Type |
-|-----|------|
-| JS | `RexecError` (`statusCode`, `message`) |
-| Python | `RexecAPIError`, `RexecConnectionError` |
-| Go | `*rexec.APIError` |
-| Rust | `rexec::Error` |
-| Ruby | `Rexec::APIError` |
-| .NET | `RexecException` |
-| Java | `RexecException` |
-| PHP | `RexecException` |
+---
 
 ## End-to-end smoke tests
 
 ```bash
 cd scripts/sdk-e2e
-# see README.md — list → create → get → delete for each language
+# See README.md — list → create → get → delete for each language
+# Runners: test-js.mjs, test_py.py, go/, rust_e2e, test_rb.rb,
+#          dotnet_e2e, java_e2e, test_php.php
 ```
 
-## Further reading
+---
 
-- [Getting started](SDK_GETTING_STARTED.md)
-- [Publishing / CI](SDK_PUBLISHING.md)
-- Per-language READMEs under [`sdk/`](../sdk/)
+## References
+
+| Resource | Link |
+|----------|------|
+| Quick start | [SDK_GETTING_STARTED.md](SDK_GETTING_STARTED.md) |
+| Publishing / CI | [SDK_PUBLISHING.md](SDK_PUBLISHING.md) |
+| Per-language READMEs | [`sdk/*/README.md`](../sdk/) |
+| Product site | https://rexec.sh |
+| Monorepo | https://github.com/PipeOpsHQ/Rexec |
+| npm | https://www.npmjs.com/package/pipeops-rexec |
+| PyPI | https://pypi.org/project/pipeops-rexec/ |
+| crates.io | https://crates.io/crates/pipeops-rexec |
+| RubyGems | https://rubygems.org/gems/pipeops-rexec |
+| NuGet | https://www.nuget.org/packages/PipeOps.Rexec |
+| Maven | https://repo1.maven.org/maven2/io/pipeops/rexec/ |
+| Go module | https://github.com/PipeOpsHQ/rexec-go |
+| PHP source | https://github.com/PipeOpsHQ/rexec-php |

--- a/docs/SDK_GETTING_STARTED.md
+++ b/docs/SDK_GETTING_STARTED.md
@@ -1,55 +1,278 @@
-# SDK Getting Started
+# Rexec SDK Quick Start
 
-## Prerequisites
+**~5 minutes** to list, create, inspect, and delete a sandbox with an official client.
 
-1. A Rexec instance URL (self-hosted or https://rexec.sh)
-2. An API token (**Settings → API Tokens**) or a guest session token
+**Rexec** is an AI-native sandbox platform: instant, isolated Linux environments (containers) via API, UI, and CLI. Official language SDKs wrap the same REST + WebSocket API so agents and apps can manage sandboxes, files, and interactive terminals.
+
+| | |
+|--|--|
+| **Hosted API** | `https://rexec.sh` |
+| **Auth** | `Authorization: Bearer <token>` |
+| **SDK line** | **v1.0.1** |
+| **Full reference** | [SDK.md](SDK.md) |
+| **In-app docs** | `https://rexec.sh` → `/docs/sdk` |
+| **Monorepo** | [github.com/PipeOpsHQ/Rexec](https://github.com/PipeOpsHQ/Rexec) |
+
+> **E2E verified:** `list` → `create` → `get` → `delete` against a live instance.  
+> Smoke runners: [`scripts/sdk-e2e/`](../scripts/sdk-e2e/).
+
+---
+
+## 1. Prerequisites
+
+1. A Rexec base URL (hosted `https://rexec.sh` or your self-hosted origin).
+2. A Bearer token:
+   - **API token** (production / apps): Rexec UI → **Settings** → **API Tokens**
+   - **Guest JWT** (short-lived smoke tests):
 
 ```bash
 export REXEC_URL=https://rexec.sh
 export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \
   -H 'Content-Type: application/json' \
-  -d '{"username":"demo","email":"you@example.com"}' \
+  -d '{"username":"docs_demo","email":"you@example.com"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
 ```
 
-## Install
+All official SDKs inject `Authorization: Bearer <token>` for you.
 
-| Language | Command |
-|----------|---------|
-| JavaScript | `npm install pipeops-rexec` |
-| Python | `pip install pipeops-rexec` |
-| Go | `go get github.com/PipeOpsHQ/rexec-go@v1.0.1` |
-| Rust | `cargo add pipeops-rexec` |
-| Ruby | `gem install pipeops-rexec` |
-| .NET | `dotnet add package PipeOps.Rexec` |
-| Java / Kotlin | `io.pipeops:rexec:1.0.1` (or `cd sdk/java && mvn install`) |
-| PHP | `composer require pipeopshq/rexec` |
+Guest sessions are limited (fewer concurrent sandboxes / shorter lifetime). Prefer API tokens for real apps.
 
-## Minimal flow (all SDKs)
+---
+
+## 2. Install (v1.0.1)
+
+| Language | Package | Install |
+|----------|---------|---------|
+| **JavaScript / TypeScript** | [`pipeops-rexec`](https://www.npmjs.com/package/pipeops-rexec) | `npm install pipeops-rexec` |
+| **Python** | [`pipeops-rexec`](https://pypi.org/project/pipeops-rexec/) (`import rexec`) | `pip install pipeops-rexec` |
+| **Go** | [`github.com/PipeOpsHQ/rexec-go`](https://github.com/PipeOpsHQ/rexec-go) | `go get github.com/PipeOpsHQ/rexec-go@v1.0.1` |
+| **Rust** | crate [`pipeops-rexec`](https://crates.io/crates/pipeops-rexec) (`use rexec::…`) | `cargo add pipeops-rexec` |
+| **Ruby** | gem [`pipeops-rexec`](https://rubygems.org/gems/pipeops-rexec) | `gem install pipeops-rexec` |
+| **C# / .NET** | [`PipeOps.Rexec`](https://www.nuget.org/packages/PipeOps.Rexec) (namespace `Rexec`) | `dotnet add package PipeOps.Rexec` |
+| **Java / Kotlin** | `io.pipeops:rexec:1.0.1` | Maven/Gradle (see below) |
+| **PHP** | [`pipeopshq/rexec`](https://packagist.org/packages/pipeopshq/rexec) | `composer require pipeopshq/rexec` |
+
+### Fallback installs
+
+```bash
+# PHP until Packagist is live
+composer config repositories.rexec-php vcs https://github.com/PipeOpsHQ/rexec-php
+composer require pipeopshq/rexec:^1.0
+
+# Java from monorepo
+cd sdk/java && mvn install -DskipTests
+```
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>io.pipeops</groupId>
+  <artifactId>rexec</artifactId>
+  <version>1.0.1</version>
+</dependency>
+```
+
+> Package names are prefixed (`pipeops-rexec`, `PipeOps.Rexec`, `pipeopshq/rexec`) because bare `rexec` is taken on several registries. Rust and Python still **import** as `rexec`.
+
+---
+
+## 3. Image aliases (critical)
+
+Hosted Rexec validates images against a fixed catalog of **aliases**, not arbitrary Docker Hub tags.
+
+| Do use | Don’t use on hosted |
+|--------|---------------------|
+| `ubuntu`, `ubuntu-24`, `ubuntu-22` | `ubuntu:24.04` |
+| `debian`, `alpine`, `fedora` | `debian:latest` |
+| `archlinux`, … | random Hub tags |
+
+Full catalog: `GET /api/images` on your instance.
+
+Create often returns immediately with `status: "creating"` (async provision). If you need a ready shell, poll `get(id)` until `status === "running"`.
+
+---
+
+## 4. Minimal happy path
+
+Every language does the same four steps:
 
 1. **List** sandboxes  
-2. **Create** with an image **alias** (e.g. `ubuntu`, not `ubuntu:24.04`)  
+2. **Create** with `image: "ubuntu"` (optional `name`)  
 3. **Get** by id  
 4. **Delete** when finished  
 
-Full language examples: [SDK.md](SDK.md).
+There is **no** first-class `exec()` HTTP API. Run commands via the **terminal WebSocket** (see [SDK.md](SDK.md#terminal-websocket)).
 
-## Image aliases
-
-Hosted Rexec validates images against a fixed catalog. Common aliases:
-
-`ubuntu`, `ubuntu-24`, `ubuntu-22`, `debian`, `alpine`, `fedora`, `archlinux`, …
-
-Fetch the full list: `GET /api/images`.
-
-## Smoke tests
+### JavaScript / TypeScript (primary)
 
 ```bash
-cd scripts/sdk-e2e
-# See README.md for per-language runners (used in CI-style verification)
+npm install pipeops-rexec
+# Node WebSockets: npm install ws
 ```
 
-## Publishing packages
+```typescript
+import { RexecClient } from 'pipeops-rexec';
 
-Only via GitHub Actions: [SDK_PUBLISHING.md](SDK_PUBLISHING.md).
+const client = new RexecClient({
+  baseURL: process.env.REXEC_URL!,
+  token: process.env.REXEC_TOKEN!,
+});
+
+const list = await client.containers.list(); // always an array (SDK normalizes API wrapper)
+const c = await client.containers.create({ image: 'ubuntu', name: 'demo' });
+console.log(c.id, c.status); // often "creating" at first
+
+const got = await client.containers.get(c.id);
+await client.containers.delete(c.id);
+```
+
+### Python (primary)
+
+```bash
+pip install pipeops-rexec
+```
+
+```python
+import asyncio
+import os
+from rexec import RexecClient
+
+async def main():
+    async with RexecClient(os.environ["REXEC_URL"], os.environ["REXEC_TOKEN"]) as client:
+        print(await client.containers.list())
+        c = await client.containers.create(image="ubuntu", name="demo")
+        print(c.id, c.status)
+        await client.containers.get(c.id)
+        await client.containers.delete(c.id)
+
+asyncio.run(main())
+```
+
+### Other languages (same flow)
+
+<details>
+<summary>Go</summary>
+
+```bash
+go get github.com/PipeOpsHQ/rexec-go@v1.0.1
+```
+
+```go
+client := rexec.NewClient(os.Getenv("REXEC_URL"), os.Getenv("REXEC_TOKEN"))
+c, _ := client.Containers.Create(ctx, &rexec.CreateContainerRequest{Image: "ubuntu", Name: "demo"})
+_ = client.Containers.Delete(ctx, c.ID)
+```
+
+</details>
+
+<details>
+<summary>Rust</summary>
+
+```bash
+cargo add pipeops-rexec
+```
+
+```rust
+use rexec::{CreateContainerRequest, RexecClient};
+let client = RexecClient::new(url, token);
+let c = client.containers().create(CreateContainerRequest::new("ubuntu").name("demo")).await?;
+client.containers().delete(&c.id).await?;
+```
+
+</details>
+
+<details>
+<summary>Ruby</summary>
+
+```bash
+gem install pipeops-rexec
+```
+
+```ruby
+require "rexec"
+client = Rexec::Client.new(ENV["REXEC_URL"], ENV["REXEC_TOKEN"])
+c = client.containers.create(image: "ubuntu", name: "demo")
+client.containers.delete(c.id)
+```
+
+</details>
+
+<details>
+<summary>C# / .NET</summary>
+
+```bash
+dotnet add package PipeOps.Rexec
+```
+
+```csharp
+using Rexec;
+using var client = new RexecClient(url, token);
+var c = await client.Containers.CreateAsync(new CreateContainerRequest("ubuntu") { Name = "demo" });
+await client.Containers.DeleteAsync(c!.Id);
+```
+
+</details>
+
+<details>
+<summary>Java / Kotlin</summary>
+
+```java
+RexecClient client = new RexecClient(url, token);
+Container c = client.containers().create(new CreateContainerRequest("ubuntu").setName("demo"));
+client.containers().delete(c.getId());
+```
+
+</details>
+
+<details>
+<summary>PHP</summary>
+
+```bash
+composer require pipeopshq/rexec
+```
+
+```php
+$client = new Rexec\RexecClient(getenv('REXEC_URL'), getenv('REXEC_TOKEN'));
+$c = $client->containers()->create('ubuntu', ['name' => 'demo']);
+$client->containers()->delete($c->id);
+```
+
+</details>
+
+Full copy-paste samples for every language: [SDK.md](SDK.md#language-examples).
+
+---
+
+## 5. What the SDKs cover
+
+| Surface | Capabilities |
+|---------|----------------|
+| **Containers** | list, create, get, start, stop, delete |
+| **Files** | list dir, read, write (often base64), mkdir (JS+), delete |
+| **Terminal** | WebSocket connect, `write` / `onData`, resize, close |
+
+Raw HTTP equivalents and error types live in the [API Reference](SDK.md).
+
+---
+
+## 6. Next steps
+
+| Topic | Where |
+|-------|--------|
+| Auth, lifecycle, files, terminal protocol, errors | [SDK.md](SDK.md) |
+| Publish / CI | [SDK_PUBLISHING.md](SDK_PUBLISHING.md) |
+| Per-language README | [`sdk/*/README.md`](../sdk/) |
+| E2E runners | [`scripts/sdk-e2e/`](../scripts/sdk-e2e/) |
+| Product | [rexec.sh](https://rexec.sh) |
+
+### Registry links
+
+- [npm `pipeops-rexec`](https://www.npmjs.com/package/pipeops-rexec)
+- [PyPI `pipeops-rexec`](https://pypi.org/project/pipeops-rexec/)
+- [crates.io `pipeops-rexec`](https://crates.io/crates/pipeops-rexec)
+- [RubyGems `pipeops-rexec`](https://rubygems.org/gems/pipeops-rexec)
+- [NuGet `PipeOps.Rexec`](https://www.nuget.org/packages/PipeOps.Rexec)
+- [Maven `io/pipeops/rexec`](https://repo1.maven.org/maven2/io/pipeops/rexec/)
+- [Go module](https://github.com/PipeOpsHQ/rexec-go)
+- [PHP source](https://github.com/PipeOpsHQ/rexec-php)

--- a/frontend/src/lib/components/SDKDocs.svelte
+++ b/frontend/src/lib/components/SDKDocs.svelte
@@ -199,6 +199,12 @@ $client->containers()->delete($c->id);`,
 
     $: activeSdk = sdks.find((s) => s.id === activeTab) ?? sdks[0];
     $: activeCode = codeExamples[activeTab] ?? "";
+
+    const guestAuthSnippet = `export REXEC_URL=https://rexec.sh
+export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"username":"docs_demo","email":"you@example.com"}' \\
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")`;
 </script>
 
 <div class="docs-page">
@@ -215,17 +221,43 @@ $client->containers()->delete($c->id);`,
             <h1>Rexec SDKs</h1>
             <p class="subtitle">
                 Official clients for the Rexec API (v1.0.1) — list, create, get,
-                and delete sandboxes from your code
+                and delete sandboxes from your code. Same REST + WebSocket surface
+                in JS, Python, Go, Rust, Ruby, .NET, Java/Kotlin, and PHP.
             </p>
         </header>
+
+        <section class="docs-section">
+            <h2>Auth</h2>
+            <p>
+                API token: <strong>Settings → API Tokens</strong>. Or guest JWT for
+                smoke tests:
+            </p>
+            <pre class="code-block"><code>{guestAuthSnippet}</code></pre>
+            <p class="muted">
+                Full quick start &amp; reference:
+                <a
+                    href="https://github.com/PipeOpsHQ/Rexec/blob/main/docs/SDK_GETTING_STARTED.md"
+                    target="_blank"
+                    rel="noreferrer">SDK_GETTING_STARTED.md</a
+                >
+                ·
+                <a
+                    href="https://github.com/PipeOpsHQ/Rexec/blob/main/docs/SDK.md"
+                    target="_blank"
+                    rel="noreferrer">SDK.md</a
+                >
+            </p>
+        </section>
 
         <section class="docs-section">
             <h2>Install</h2>
             <p>
                 Use image aliases such as <code>ubuntu</code>,
                 <code>debian</code>, or <code>alpine</code> (not
-                <code>ubuntu:24.04</code> on hosted Rexec). Set
-                <code>REXEC_URL</code> and <code>REXEC_TOKEN</code>.
+                <code>ubuntu:24.04</code> on hosted Rexec). Create may return
+                <code>status: creating</code> — poll <code>get</code> until
+                <code>running</code> if you need a ready shell. There is no primary
+                HTTP <code>exec()</code>; use the terminal WebSocket for commands.
             </p>
 
             <div class="sdk-list">

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -29,15 +29,15 @@ using Rexec;
 var client = new RexecClient("https://your-instance.com", "your-api-token");
 
 // Create a container
-var container = await client.Containers.CreateAsync("ubuntu:24.04");
+var container = await client.Containers.CreateAsync("ubuntu");
 Console.WriteLine($"Created: {container.Id}");
 
 // Start it
 await client.Containers.StartAsync(container.Id);
 
-// Execute a command
-var result = await client.Containers.ExecAsync(container.Id, "echo 'Hello from .NET!'");
-Console.WriteLine(result.Stdout);
+// Run interactive commands via Terminal WebSocket (no primary HTTP exec API)
+// var term = await client.Terminal.ConnectAsync(container.Id);
+// await term.WriteAsync("echo 'Hello from .NET!'\n");
 
 // Clean up
 await client.Containers.DeleteAsync(container.Id);
@@ -64,7 +64,7 @@ await client.Containers.StopAsync(containerId);
 await client.Containers.DeleteAsync(containerId);
 
 // Execute commands
-var result = await client.Containers.ExecAsync(containerId, "python --version");
+// Terminal WebSocket preferred over any exec helper — see monorepo docs/SDK.md
 if (result.IsSuccess)
 {
     Console.WriteLine(result.Stdout);

--- a/sdk/dotnet/RexecClient.cs
+++ b/sdk/dotnet/RexecClient.cs
@@ -11,7 +11,7 @@ namespace Rexec;
 /// <example>
 /// <code>
 /// var client = new RexecClient("https://your-instance.com", "your-token");
-/// var container = await client.Containers.CreateAsync("ubuntu:24.04");
+/// var container = await client.Containers.CreateAsync("ubuntu");
 /// await client.Containers.StartAsync(container.Id);
 /// </code>
 /// </example>

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -29,7 +29,7 @@ func main() {
 
     // Create a container
     container, err := client.Containers.Create(ctx, &rexec.CreateContainerRequest{
-        Image: "ubuntu:24.04",
+        Image: "ubuntu",
         Name:  "my-sandbox",
     })
     if err != nil {
@@ -79,7 +79,7 @@ container, err := client.Containers.Get(ctx, containerID)
 
 // Create a container
 container, err := client.Containers.Create(ctx, &rexec.CreateContainerRequest{
-    Image: "ubuntu:24.04",
+    Image: "ubuntu",
     Name:  "my-container",
     Environment: map[string]string{
         "MY_VAR": "value",

--- a/sdk/go/rexec.go
+++ b/sdk/go/rexec.go
@@ -9,7 +9,7 @@
 //
 //	// Create a container
 //	container, err := client.Containers.Create(ctx, &rexec.CreateContainerRequest{
-//	    Image: "ubuntu:24.04",
+//	    Image: "ubuntu",
 //	    Name:  "my-sandbox",
 //	})
 //

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -47,7 +47,7 @@ public class Example {
 
         System.out.println("count " + client.containers().list().size());
 
-        // Prefer image aliases: ubuntu, debian, alpine (not ubuntu:24.04 on hosted Rexec)
+        // Prefer image aliases: ubuntu, debian, alpine (not ubuntu on hosted Rexec)
         Container c = client.containers().create(
             new CreateContainerRequest("ubuntu").setName("java-demo")
         );

--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -30,7 +30,7 @@ const client = new RexecClient({
 
 // Create a container
 const container = await client.containers.create({
-  image: 'ubuntu:24.04',
+  image: 'ubuntu',
   name: 'my-sandbox'
 });
 
@@ -74,7 +74,7 @@ const container = await client.containers.get(containerId);
 
 // Create a container
 const container = await client.containers.create({
-  image: 'ubuntu:24.04',
+  image: 'ubuntu',
   name: 'my-container',
   environment: {
     MY_VAR: 'value'
@@ -199,7 +199,7 @@ const client = new RexecClient({
   token: 'your-api-token'
 });
 
-const container = await client.containers.create({ image: 'ubuntu:24.04' });
+const container = await client.containers.create({ image: 'ubuntu' });
 const rexecTerminal = await client.terminal.connect(container.id, {
   cols: xterm.cols,
   rows: xterm.rows
@@ -235,7 +235,7 @@ import {
 
 // All types are available
 const request: CreateContainerRequest = {
-  image: 'ubuntu:24.04',
+  image: 'ubuntu',
   name: 'typed-container'
 };
 ```

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -277,7 +277,7 @@ export class TerminalService {
  * 
  * // Create a container
  * const container = await client.containers.create({
- *   image: 'ubuntu:24.04',
+ *   image: 'ubuntu',
  *   name: 'my-sandbox'
  * });
  * 

--- a/sdk/php/README.md
+++ b/sdk/php/README.md
@@ -43,7 +43,7 @@ try {
     $list = $client->containers()->list();
     echo 'count: ' . count($list) . PHP_EOL;
 
-    // Prefer image aliases: ubuntu, debian, alpine (not ubuntu:24.04 on hosted Rexec)
+    // Prefer image aliases: ubuntu, debian, alpine (not ubuntu on hosted Rexec)
     $container = $client->containers()->create('ubuntu', [
         'name' => 'php-demo',
     ]);

--- a/sdk/php/src/ContainerService.php
+++ b/sdk/php/src/ContainerService.php
@@ -52,7 +52,7 @@ class ContainerService
      * Create a new container.
      *
      * Prefer image aliases such as `ubuntu`, `debian`, or `alpine`
-     * (not `ubuntu:24.04` on hosted Rexec).
+     * (not `ubuntu` on hosted Rexec).
      *
      * @param string $image Image alias or name
      * @param array{name?: string, environment?: array<string, string>, labels?: array<string, string>} $options

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -18,7 +18,7 @@ async def main():
     async with RexecClient("https://your-instance.com", "your-token") as client:
         # Create a container
         container = await client.containers.create(
-            image="ubuntu:24.04",
+            image="ubuntu",
             name="my-sandbox"
         )
         print(f"Created container: {container.id}")
@@ -73,7 +73,7 @@ container = await client.containers.get(container_id)
 
 # Create a container
 container = await client.containers.create(
-    image="ubuntu:24.04",
+    image="ubuntu",
     name="my-container",
     environment={"MY_VAR": "value"},
     labels={"project": "demo"}
@@ -172,7 +172,7 @@ async def create_batch(client: RexecClient, count: int) -> list[Container]:
     
     tasks = [
         client.containers.create(
-            image="ubuntu:24.04",
+            image="ubuntu",
             name=f"worker-{i}"
         )
         for i in range(count)
@@ -236,7 +236,7 @@ from rexec import (
     Terminal,
 )
 
-container: Container = await client.containers.create(image="ubuntu:24.04")
+container: Container = await client.containers.create(image="ubuntu")
 files: list[FileInfo] = await client.files.list(container.id, "/")
 ```
 

--- a/sdk/python/rexec/__init__.py
+++ b/sdk/python/rexec/__init__.py
@@ -5,7 +5,7 @@ Example usage:
     from rexec import RexecClient
 
     async with RexecClient("https://your-instance.com", "your-token") as client:
-        container = await client.containers.create(image="ubuntu:24.04")
+        container = await client.containers.create(image="ubuntu")
         async with client.terminal.connect(container.id) as term:
             await term.write(b"echo hello\\n")
             async for data in term:

--- a/sdk/python/rexec/client.py
+++ b/sdk/python/rexec/client.py
@@ -20,7 +20,7 @@ class RexecClient:
     Example:
         async with RexecClient("https://your-instance.com", "your-token") as client:
             containers = await client.containers.list()
-            container = await client.containers.create(image="ubuntu:24.04")
+            container = await client.containers.create(image="ubuntu")
 
             async with client.terminal.connect(container.id) as term:
                 await term.write(b"echo hello\\n")

--- a/sdk/python/rexec/containers.py
+++ b/sdk/python/rexec/containers.py
@@ -62,7 +62,7 @@ class ContainerService:
         Create a new container.
 
         Args:
-            image: Docker image to use (e.g., "ubuntu:24.04").
+            image: Docker image to use (e.g., "ubuntu").
             name: Optional container name.
             environment: Optional environment variables.
             labels: Optional labels.
@@ -72,7 +72,7 @@ class ContainerService:
 
         Example:
             container = await client.containers.create(
-                image="ubuntu:24.04",
+                image="ubuntu",
                 name="my-sandbox",
                 environment={"MY_VAR": "value"}
             )

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -25,7 +25,7 @@ client = Rexec::Client.new("https://your-instance.com", "your-token")
 
 # Create a container
 container = client.containers.create(
-  image: "ubuntu:24.04",
+  image: "ubuntu",
   name: "my-sandbox"
 )
 puts "Created container: #{container.id}"
@@ -74,7 +74,7 @@ container = client.containers.get("container-id")
 
 # Create a container
 container = client.containers.create(
-  image: "ubuntu:24.04",
+  image: "ubuntu",
   name: "my-container",
   environment: { "MY_VAR" => "value" },
   labels: { "project" => "demo" }
@@ -176,7 +176,7 @@ def create_batch(client, count)
   futures = (0...count).map do |i|
     Concurrent::Future.execute do
       client.containers.create(
-        image: "ubuntu:24.04",
+        image: "ubuntu",
         name: "worker-#{i}"
       )
     end

--- a/sdk/ruby/lib/rexec.rb
+++ b/sdk/ruby/lib/rexec.rb
@@ -12,7 +12,7 @@ require_relative "rexec/terminal"
 # @example Basic usage
 #   client = Rexec::Client.new("https://your-instance.com", "your-token")
 #   
-#   container = client.containers.create(image: "ubuntu:24.04")
+#   container = client.containers.create(image: "ubuntu")
 #   puts "Created: #{container.id}"
 #   
 #   terminal = client.terminal.connect(container.id)

--- a/sdk/ruby/lib/rexec/container.rb
+++ b/sdk/ruby/lib/rexec/container.rb
@@ -60,7 +60,7 @@ module Rexec
     #
     # @example
     #   container = client.containers.create(
-    #     image: "ubuntu:24.04",
+    #     image: "ubuntu",
     #     name: "my-sandbox",
     #     environment: { "MY_VAR" => "value" }
     #   )

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -34,7 +34,7 @@ async fn main() -> Result<(), rexec::Error> {
 
     // Create a container
     let container = client.containers()
-        .create(CreateContainerRequest::new("ubuntu:24.04")
+        .create(CreateContainerRequest::new("ubuntu")
             .name("my-sandbox"))
         .await?;
 
@@ -87,7 +87,7 @@ let container = client.containers().get("container-id").await?;
 
 // Create a container with builder pattern
 let container = client.containers()
-    .create(CreateContainerRequest::new("ubuntu:24.04")
+    .create(CreateContainerRequest::new("ubuntu")
         .name("my-container")
         .env("MY_VAR", "value")
         .label("project", "demo"))
@@ -187,7 +187,7 @@ async fn create_batch(client: &RexecClient, count: usize) -> Vec<Container> {
     let futures: Vec<_> = (0..count)
         .map(|i| {
             client.containers().create(
-                CreateContainerRequest::new("ubuntu:24.04")
+                CreateContainerRequest::new("ubuntu")
                     .name(format!("worker-{}", i))
             )
         })

--- a/sdk/rust/src/containers.rs
+++ b/sdk/rust/src/containers.rs
@@ -64,7 +64,7 @@ impl ContainerService {
     /// # async fn example() -> Result<(), rexec::Error> {
     /// let client = RexecClient::new("https://example.com", "token");
     /// let container = client.containers()
-    ///     .create(CreateContainerRequest::new("ubuntu:24.04")
+    ///     .create(CreateContainerRequest::new("ubuntu")
     ///         .name("my-sandbox")
     ///         .env("MY_VAR", "value"))
     ///     .await?;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -17,7 +17,7 @@
 //!     // Create a container
 //!     let container = client.containers()
 //!         .create(CreateContainerRequest {
-//!             image: "ubuntu:24.04".into(),
+//!             image: "ubuntu".into(),
 //!             name: Some("my-sandbox".into()),
 //!             ..Default::default()
 //!         })


### PR DESCRIPTION
## Summary
Rexec SDK documentation for **v1.0.1** across JS, Python, Go, Rust, Ruby, .NET, Java/Kotlin, and PHP.

- **Quick start** (`docs/SDK_GETTING_STARTED.md`): auth (token + guest curl), install matrix, image aliases, list→create→get→delete
- **Reference** (`docs/SDK.md`): shared containers/files/terminal surface, async create, no primary `exec()`, errors, registry links
- **In-app** `/docs/sdk`: guest auth + links to monorepo docs
- Example cleanup: prefer `ubuntu` aliases; avoid presenting HTTP `exec()` as the main path

## Test plan
- [ ] Read docs/SDK_GETTING_STARTED.md end-to-end
- [ ] Spot-check language samples in docs/SDK.md
- [ ] Open /docs/sdk in app (after frontend build) for auth section