### PR TITLE
fix(api): merge custom labels on container create

### DIFF
--- a/internal/api/handlers/container.go
+++ b/internal/api/handlers/container.go
@@ -543,6 +543,20 @@ func (h *ContainerHandler) Create(c *gin.Context) {
 		},
 	}
 
+	// Merge caller-provided labels (e.g. pipeops.workspace_id from PipeOps BFF).
+	// Platform rexec.* keys set above win if both set the same key.
+	if len(req.Labels) > 0 {
+		for k, v := range req.Labels {
+			if k == "" || v == "" {
+				continue
+			}
+			if _, reserved := cfg.Labels[k]; reserved && strings.HasPrefix(k, "rexec.") {
+				continue
+			}
+			cfg.Labels[k] = v
+		}
+	}
+
 	// Mark guest containers with special label for cleanup
 	if isGuest || tier == "guest" {
 		cfg.Labels["rexec.tier"] = "guest"
@@ -1926,6 +1940,19 @@ func (h *ContainerHandler) CreateWithProgress(c *gin.Context) {
 			"rexec.user_id":  userID,
 			"rexec.use_tmux": useTmux,
 		},
+	}
+
+	// Merge caller-provided labels (e.g. pipeops.workspace_id).
+	if len(req.Labels) > 0 {
+		for k, v := range req.Labels {
+			if k == "" || v == "" {
+				continue
+			}
+			if _, reserved := cfg.Labels[k]; reserved && strings.HasPrefix(k, "rexec.") {
+				continue
+			}
+			cfg.Labels[k] = v
+		}
 	}
 
 	if isGuest || tier == "guest" {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -315,12 +315,15 @@ type CreateContainerRequest struct {
 	Image       string `json:"image" binding:"required"` // Image type (ubuntu, debian, etc.) or "custom"
 	CustomImage string `json:"custom_image,omitempty"`   // Required when Image is "custom"
 	Role        string `json:"role,omitempty"`           // Optional role (node, python, etc.)
+	// Labels are merged into container labels (e.g. pipeops.workspace_id for BFF tenancy).
+	// Reserved rexec.* keys set by the platform still take precedence when set after merge.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Shell customization
 	Shell *ShellConfig `json:"shell,omitempty"` // Optional shell config (defaults to enhanced)
 	// Trial resource customization (within limits)
-	MemoryMB  int64  `json:"memory_mb,omitempty"`  // Optional: custom memory (256-1024 MB for trial)
-	CPUShares int64  `json:"cpu_shares,omitempty"` // Optional: custom CPU shares (256-1024 for trial)
-	DiskMB    int64  `json:"disk_mb,omitempty"`    // Optional: custom disk (1024-4096 MB for trial)
+	MemoryMB  int64 `json:"memory_mb,omitempty"`  // Optional: custom memory (256-1024 MB for trial)
+	CPUShares int64 `json:"cpu_shares,omitempty"` // Optional: custom CPU shares (256-1024 for trial)
+	DiskMB    int64 `json:"disk_mb,omitempty"`    // Optional: custom disk (1024-4096 MB for trial)
 }
 
 // TrialResourceLimits defines the min/max resource limits for trial users


### PR DESCRIPTION
## Summary
PipeOps BFF sends \`pipeops.workspace_id\` (and related) labels on create. Those were ignored, so multi-tenant list/session checks failed.

Merge \`req.Labels\` into container labels on both create paths (async + streaming).

## Test plan
- [ ] POST /api/containers with labels → Get shows labels
- [ ] PipeOps create + session succeeds with ownership + labels