### PR TITLE
fix(ui): polish /docs/sdk page glitches

### DIFF
--- a/cmd/rexec/main.go
+++ b/cmd/rexec/main.go
@@ -676,6 +676,8 @@ func runServer() {
 		authGroup.GET("/callback", authHandler.OAuthCallback)
 		authGroup.GET("/signin", authHandler.OAuthCallback) // Alternative callback path
 		authGroup.POST("/oauth/exchange", authHandler.OAuthExchange)
+		// Server-to-server identity bridge (PipeOps BFF → per-user Rexec JWT)
+		authGroup.POST("/pipeops/assert", authHandler.PipeOpsAssert)
 	}
 
 	// Internal SSH Gateway routes (called by the SSH gateway, no user auth)

--- a/frontend/src/lib/components/SDKDocs.svelte
+++ b/frontend/src/lib/components/SDKDocs.svelte
@@ -31,56 +31,56 @@
             name: "JavaScript / TypeScript",
             install: "npm install pipeops-rexec",
             registry: "https://www.npmjs.com/package/pipeops-rexec",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/js",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/js",
         },
         {
             id: "python",
             name: "Python",
             install: "pip install pipeops-rexec",
             registry: "https://pypi.org/project/pipeops-rexec/",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/python",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/python",
         },
         {
             id: "go",
             name: "Go",
             install: "go get github.com/PipeOpsHQ/rexec-go@v1.0.1",
             registry: "https://github.com/PipeOpsHQ/rexec-go",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/go",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/go",
         },
         {
             id: "rust",
             name: "Rust",
             install: "cargo add pipeops-rexec",
             registry: "https://crates.io/crates/pipeops-rexec",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/rust",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/rust",
         },
         {
             id: "ruby",
             name: "Ruby",
             install: "gem install pipeops-rexec",
             registry: "https://rubygems.org/gems/pipeops-rexec",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/ruby",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/ruby",
         },
         {
             id: "dotnet",
             name: "C# / .NET",
             install: "dotnet add package PipeOps.Rexec",
             registry: "https://www.nuget.org/packages/PipeOps.Rexec",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/dotnet",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/dotnet",
         },
         {
             id: "java",
             name: "Java / Kotlin",
-            install: "io.pipeops:rexec:1.0.1 (Maven/Gradle)",
-            registry: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/java",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/java",
+            install: "io.pipeops:rexec:1.0.1",
+            registry: "https://repo1.maven.org/maven2/io/pipeops/rexec/",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/java",
         },
         {
             id: "php",
             name: "PHP",
             install: "composer require pipeopshq/rexec",
-            registry: "https://packagist.org/packages/pipeopshq/rexec",
-            github: "https://github.com/PipeOpsHQ/rexec/tree/main/sdk/php",
+            registry: "https://github.com/PipeOpsHQ/rexec-php",
+            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/php",
         },
     ];
 
@@ -92,24 +92,28 @@ const client = new RexecClient({
   token: process.env.REXEC_TOKEN,
 });
 
+// List sandboxes (SDK normalizes API list wrapper)
 const list = await client.containers.list();
-const container = await client.containers.create({
+
+// Create a sandbox (image alias — not ubuntu:24.04 on hosted)
+const sandbox = await client.containers.create({
   image: 'ubuntu',
   name: 'demo',
 });
-console.log(container.id, container.status);
-await client.containers.get(container.id);
-await client.containers.delete(container.id);`,
+console.log(sandbox.id, sandbox.status); // may be "creating"
+
+await client.containers.get(sandbox.id);
+await client.containers.delete(sandbox.id);`,
         python: `import asyncio, os
 from rexec import RexecClient
 
 async def main():
     async with RexecClient(os.environ["REXEC_URL"], os.environ["REXEC_TOKEN"]) as client:
         print(await client.containers.list())
-        c = await client.containers.create(image="ubuntu", name="demo")
-        print(c.id, c.status)
-        await client.containers.get(c.id)
-        await client.containers.delete(c.id)
+        sandbox = await client.containers.create(image="ubuntu", name="demo")
+        print(sandbox.id, sandbox.status)
+        await client.containers.get(sandbox.id)
+        await client.containers.delete(sandbox.id)
 
 asyncio.run(main())`,
         go: `package main
@@ -118,6 +122,7 @@ import (
     "context"
     "fmt"
     "os"
+
     rexec "github.com/PipeOpsHQ/rexec-go"
 )
 
@@ -130,10 +135,12 @@ func main() {
         Image: "ubuntu",
         Name:  "demo",
     })
-    if err != nil { panic(err) }
+    if err != nil {
+        panic(err)
+    }
     fmt.Println(c.ID, c.Status)
-    client.Containers.Get(ctx, c.ID)
-    client.Containers.Delete(ctx, c.ID)
+    _, _ = client.Containers.Get(ctx, c.ID)
+    _ = client.Containers.Delete(ctx, c.ID)
 }`,
         rust: `use rexec::{CreateContainerRequest, RexecClient};
 
@@ -145,7 +152,8 @@ async fn main() -> Result<(), rexec::Error> {
     );
     let list = client.containers().list().await?;
     println!("{}", list.len());
-    let c = client.containers()
+    let c = client
+        .containers()
         .create(CreateContainerRequest::new("ubuntu").name("demo"))
         .await?;
     println!("{} {}", c.id, c.status);
@@ -187,6 +195,7 @@ client.containers().get(c.getId());
 client.containers().delete(c.getId());`,
         php: `<?php
 require 'vendor/autoload.php';
+
 use Rexec\\RexecClient;
 
 $client = new RexecClient(getenv('REXEC_URL'), getenv('REXEC_TOKEN'));
@@ -200,11 +209,15 @@ $client->containers()->delete($c->id);`,
     $: activeSdk = sdks.find((s) => s.id === activeTab) ?? sdks[0];
     $: activeCode = codeExamples[activeTab] ?? "";
 
-    const guestAuthSnippet = `export REXEC_URL=https://rexec.sh
-export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
-  -H 'Content-Type: application/json' \\
-  -d '{"username":"docs_demo","email":"you@example.com"}' \\
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")`;
+    // Single-line-friendly guest auth (no awkward soft-wrap mid-flag)
+    const guestAuthSnippet = [
+        "export REXEC_URL=https://rexec.sh",
+        "export REXEC_TOKEN=$(curl -sS -X POST \\",
+        '  "$REXEC_URL/api/auth/guest" \\',
+        "  -H 'Content-Type: application/json' \\",
+        `  -d '{"username":"docs_demo","email":"you@example.com"}' \\`,
+        "  | python3 -c \"import sys,json; print(json.load(sys.stdin)['token'])\")",
+    ].join("\n");
 </script>
 
 <div class="docs-page">
@@ -221,55 +234,94 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
             <h1>Rexec SDKs</h1>
             <p class="subtitle">
                 Official clients for the Rexec API (v1.0.1) — list, create, get,
-                and delete sandboxes from your code. Same REST + WebSocket surface
-                in JS, Python, Go, Rust, Ruby, .NET, Java/Kotlin, and PHP.
+                and delete <strong>sandboxes</strong> from your code. Same REST +
+                WebSocket surface in JS, Python, Go, Rust, Ruby, .NET, Java/Kotlin,
+                and PHP.
             </p>
         </header>
 
         <section class="docs-section">
             <h2>Auth</h2>
             <p>
-                API token: <strong>Settings → API Tokens</strong>. Or guest JWT for
-                smoke tests:
+                Prefer an <strong>API token</strong> from
+                <strong>Settings → API Tokens</strong>. For short smoke tests, use a
+                guest JWT:
             </p>
-            <pre class="code-block"><code>{guestAuthSnippet}</code></pre>
+            <div class="code-block">
+                <div class="code-toolbar">
+                    <span class="code-label">shell</span>
+                    <button
+                        type="button"
+                        class="copy-btn"
+                        onclick={() => copyToClipboard(guestAuthSnippet, "auth")}
+                    >
+                        {copiedCommand === "auth" ? "Copied" : "Copy"}
+                    </button>
+                </div>
+                <pre><code>{guestAuthSnippet}</code></pre>
+            </div>
             <p class="muted">
-                Full quick start &amp; reference:
+                Full docs:
                 <a
                     href="https://github.com/PipeOpsHQ/Rexec/blob/main/docs/SDK_GETTING_STARTED.md"
                     target="_blank"
-                    rel="noreferrer">SDK_GETTING_STARTED.md</a
+                    rel="noreferrer">Quick start</a
                 >
                 ·
                 <a
                     href="https://github.com/PipeOpsHQ/Rexec/blob/main/docs/SDK.md"
                     target="_blank"
-                    rel="noreferrer">SDK.md</a
+                    rel="noreferrer">API reference</a
+                >
+                ·
+                <a
+                    href="https://docs.pipeops.io/docs/rexec/overview"
+                    target="_blank"
+                    rel="noreferrer">PipeOps · Sandboxes</a
                 >
             </p>
         </section>
 
         <section class="docs-section">
             <h2>Install</h2>
-            <p>
-                Use image aliases such as <code>ubuntu</code>,
-                <code>debian</code>, or <code>alpine</code> (not
-                <code>ubuntu:24.04</code> on hosted Rexec). Create may return
-                <code>status: creating</code> — poll <code>get</code> until
-                <code>running</code> if you need a ready shell. There is no primary
-                HTTP <code>exec()</code>; use the terminal WebSocket for commands.
+
+            <ul class="callouts">
+                <li>
+                    <span class="callout-label">Images</span>
+                    Use aliases like <code>ubuntu</code>, <code>debian</code>, or
+                    <code>alpine</code> — not
+                    <code class="warn">ubuntu:24.04</code> on hosted Rexec.
+                </li>
+                <li>
+                    <span class="callout-label">Create</span>
+                    May return <code>status: "creating"</code>. Poll
+                    <code>get</code> until <code>"running"</code> if you need a
+                    ready shell.
+                </li>
+                <li>
+                    <span class="callout-label">Commands</span>
+                    No primary HTTP <code>exec()</code> — use the terminal
+                    WebSocket for interactive or scripted shell input.
+                </li>
+            </ul>
+
+            <p class="muted tip">
+                Select a language to preview a sample. <code>containers.*</code> methods
+                manage <strong>sandboxes</strong>.
             </p>
 
-            <div class="sdk-list">
+            <div class="sdk-list" role="list">
                 {#each sdks as sdk (sdk.id)}
                     <div
                         class="sdk-row"
                         class:active={activeTab === sdk.id}
+                        role="listitem"
                     >
                         <button
                             type="button"
                             class="sdk-select"
                             onclick={() => (activeTab = sdk.id)}
+                            aria-pressed={activeTab === sdk.id}
                         >
                             <strong>{sdk.name}</strong>
                             <code>{sdk.install}</code>
@@ -284,11 +336,13 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
                                 {copiedCommand === sdk.id ? "Copied" : "Copy"}
                             </button>
                             <a
+                                class="link-btn"
                                 href={sdk.registry}
                                 target="_blank"
                                 rel="noreferrer">Registry</a
                             >
                             <a
+                                class="link-btn"
                                 href={sdk.github}
                                 target="_blank"
                                 rel="noreferrer">Source</a
@@ -311,6 +365,9 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
                 </button>
             </div>
             <div class="code-block">
+                <div class="code-toolbar">
+                    <span class="code-label">{activeSdk.id}</span>
+                </div>
                 <pre><code>{activeCode}</code></pre>
             </div>
         </section>
@@ -320,21 +377,28 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
             <ul class="ref-list">
                 <li>
                     <a
-                        href="https://github.com/PipeOpsHQ/rexec/blob/main/docs/SDK.md"
+                        href="https://github.com/PipeOpsHQ/Rexec/blob/main/docs/SDK.md"
                         target="_blank"
-                        rel="noreferrer">Full SDK reference (docs/SDK.md)</a
+                        rel="noreferrer">Full SDK API reference</a
                     >
                 </li>
                 <li>
                     <a
-                        href="https://github.com/PipeOpsHQ/rexec/blob/main/docs/SDK_GETTING_STARTED.md"
+                        href="https://github.com/PipeOpsHQ/Rexec/blob/main/docs/SDK_GETTING_STARTED.md"
                         target="_blank"
-                        rel="noreferrer">Getting started</a
+                        rel="noreferrer">Getting started guide</a
                     >
                 </li>
                 <li>
                     <a
-                        href="https://github.com/PipeOpsHQ/rexec/tree/main/scripts/sdk-e2e"
+                        href="https://docs.pipeops.io/docs/rexec/overview"
+                        target="_blank"
+                        rel="noreferrer">PipeOps docs · Rexec sandboxes</a
+                    >
+                </li>
+                <li>
+                    <a
+                        href="https://github.com/PipeOpsHQ/Rexec/tree/main/scripts/sdk-e2e"
                         target="_blank"
                         rel="noreferrer">E2E smoke tests</a
                     >
@@ -380,12 +444,13 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
     .docs-content {
         max-width: 900px;
         margin: 0 auto;
+        padding-bottom: 48px;
     }
 
     .docs-header {
         text-align: center;
-        margin-bottom: 48px;
-        padding-bottom: 32px;
+        margin-bottom: 40px;
+        padding-bottom: 28px;
         border-bottom: 1px solid var(--border);
     }
 
@@ -398,7 +463,7 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
     }
 
     .docs-header h1 {
-        font-size: 36px;
+        font-size: clamp(28px, 5vw, 36px);
         margin: 0 0 12px 0;
         background: linear-gradient(135deg, var(--accent), #00d4ff);
         -webkit-background-clip: text;
@@ -407,38 +472,110 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
     }
 
     .subtitle {
-        font-size: 16px;
+        font-size: 15px;
         color: var(--text-muted);
-        margin: 0;
-        line-height: 1.5;
+        margin: 0 auto;
+        line-height: 1.6;
+        max-width: 40rem;
+    }
+
+    .subtitle strong {
+        color: var(--text);
+        font-weight: 600;
+        -webkit-text-fill-color: var(--text);
     }
 
     .docs-section {
-        margin-bottom: 48px;
+        margin-bottom: 40px;
     }
 
     .docs-section h2 {
-        font-size: 20px;
-        margin: 0 0 16px 0;
-        color: var(--text);
+        font-size: 13px;
+        margin: 0 0 14px 0;
+        color: var(--text-muted);
         text-transform: uppercase;
-        letter-spacing: 1px;
+        letter-spacing: 0.08em;
+        font-weight: 600;
     }
 
     .docs-section p {
         font-size: 14px;
         color: var(--text-muted);
         line-height: 1.7;
-        margin: 0 0 16px 0;
+        margin: 0 0 14px 0;
     }
 
-    .docs-section code {
+    .docs-section p strong {
+        color: var(--text);
+        font-weight: 600;
+    }
+
+    .docs-section :not(pre) > code,
+    .docs-section p code,
+    .callouts code {
         font-family: var(--font-mono);
         font-size: 12px;
         color: var(--accent);
         background: var(--bg-secondary);
         padding: 2px 6px;
         border-radius: 4px;
+        white-space: nowrap;
+    }
+
+    .callouts code.warn {
+        color: #f87171;
+    }
+
+    .muted {
+        font-size: 13px;
+        color: var(--text-muted);
+    }
+
+    .muted a {
+        color: var(--accent);
+        text-decoration: none;
+    }
+
+    .muted a:hover {
+        text-decoration: underline;
+    }
+
+    .tip {
+        margin-top: 4px;
+        margin-bottom: 16px !important;
+    }
+
+    .callouts {
+        list-style: none;
+        margin: 0 0 16px 0;
+        padding: 0;
+        display: grid;
+        gap: 10px;
+    }
+
+    .callouts li {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 10px 12px;
+        align-items: start;
+        padding: 12px 14px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        font-size: 13px;
+        color: var(--text-muted);
+        line-height: 1.55;
+    }
+
+    .callout-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--accent);
+        padding-top: 2px;
+        min-width: 4.5rem;
     }
 
     .sdk-list {
@@ -457,16 +594,19 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
         background: var(--bg-secondary);
         border: 1px solid var(--border);
         border-radius: 8px;
+        transition:
+            border-color 0.15s ease,
+            box-shadow 0.15s ease;
     }
 
     .sdk-row.active {
         border-color: var(--accent);
-        box-shadow: 0 0 0 1px rgba(var(--accent-rgb, 0, 212, 255), 0.25);
+        box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
     }
 
     .sdk-select {
         flex: 1;
-        min-width: 220px;
+        min-width: min(100%, 240px);
         text-align: left;
         background: transparent;
         border: 0;
@@ -486,26 +626,33 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
         display: block;
         font-size: 12px;
         color: var(--accent);
-        word-break: break-all;
+        word-break: break-word;
+        overflow-wrap: anywhere;
         background: transparent;
         padding: 0;
+        white-space: normal;
     }
 
     .sdk-actions {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        gap: 10px;
+        gap: 8px;
         font-size: 12px;
     }
 
-    .sdk-actions a {
+    .link-btn {
         color: var(--accent);
         text-decoration: none;
+        padding: 6px 8px;
+        border-radius: 6px;
+        border: 1px solid transparent;
     }
 
-    .sdk-actions a:hover {
-        text-decoration: underline;
+    .link-btn:hover {
+        text-decoration: none;
+        border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+        background: color-mix(in srgb, var(--accent) 8%, transparent);
     }
 
     .copy-btn {
@@ -517,6 +664,7 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
         font-size: 12px;
         font-family: var(--font-mono);
         cursor: pointer;
+        white-space: nowrap;
     }
 
     .copy-btn:hover {
@@ -529,18 +677,41 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
         align-items: center;
         justify-content: space-between;
         gap: 12px;
-        margin-bottom: 16px;
+        margin-bottom: 12px;
     }
 
     .section-head h2 {
         margin: 0;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-muted);
     }
 
     .code-block {
         background: var(--bg-secondary);
         border: 1px solid var(--border);
         border-radius: 8px;
-        overflow: auto;
+        overflow: hidden;
+        margin-bottom: 12px;
+    }
+
+    .code-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 55%, var(--bg-secondary));
+    }
+
+    .code-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
     }
 
     .code-block pre {
@@ -551,13 +722,17 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
         color: var(--text);
         font-family: var(--font-mono);
         white-space: pre;
+        overflow-x: auto;
+        tab-size: 2;
     }
 
     .code-block code {
-        background: transparent;
-        padding: 0;
-        color: inherit;
-        font-size: inherit;
+        background: transparent !important;
+        padding: 0 !important;
+        color: inherit !important;
+        font-size: inherit !important;
+        white-space: inherit !important;
+        border-radius: 0;
     }
 
     .ref-list {
@@ -565,10 +740,35 @@ export REXEC_TOKEN=$(curl -sS -X POST "$REXEC_URL/api/auth/guest" \\
         padding-left: 1.25rem;
         color: var(--text-muted);
         font-size: 14px;
-        line-height: 1.8;
+        line-height: 1.9;
     }
 
     .ref-list a {
         color: var(--accent);
+        text-decoration: none;
+    }
+
+    .ref-list a:hover {
+        text-decoration: underline;
+    }
+
+    @media (max-width: 640px) {
+        .docs-page {
+            padding: 16px;
+        }
+
+        .sdk-row {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        .sdk-actions {
+            justify-content: flex-start;
+        }
+
+        .callouts li {
+            grid-template-columns: 1fr;
+            gap: 6px;
+        }
     }
 </style>

--- a/frontend/src/lib/components/SDKDocs.svelte
+++ b/frontend/src/lib/components/SDKDocs.svelte
@@ -71,7 +71,8 @@
         {
             id: "java",
             name: "Java / Kotlin",
-            install: "io.pipeops:rexec:1.0.1",
+            // Maven: <dependency>…</dependency> · Gradle: implementation '…'
+            install: "io.pipeops:rexec:1.0.1 (Maven/Gradle)",
             registry: "https://repo1.maven.org/maven2/io/pipeops/rexec/",
             github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/java",
         },
@@ -79,8 +80,9 @@
             id: "php",
             name: "PHP",
             install: "composer require pipeopshq/rexec",
-            registry: "https://github.com/PipeOpsHQ/rexec-php",
-            github: "https://github.com/PipeOpsHQ/Rexec/tree/main/sdk/php",
+            // Packagist is the registry; monorepo source stays under GitHub Source link
+            registry: "https://packagist.org/packages/pipeopshq/rexec",
+            github: "https://github.com/PipeOpsHQ/rexec-php",
         },
     ];
 
@@ -310,18 +312,21 @@ $client->containers()->delete($c->id);`,
                 manage <strong>sandboxes</strong>.
             </p>
 
-            <div class="sdk-list" role="list">
+            <div class="sdk-list" role="tablist" aria-label="SDK languages">
                 {#each sdks as sdk (sdk.id)}
                     <div
                         class="sdk-row"
                         class:active={activeTab === sdk.id}
-                        role="listitem"
                     >
                         <button
                             type="button"
                             class="sdk-select"
+                            role="tab"
+                            id={`sdk-tab-${sdk.id}`}
+                            aria-selected={activeTab === sdk.id}
+                            aria-controls="sdk-example-panel"
+                            tabindex={activeTab === sdk.id ? 0 : -1}
                             onclick={() => (activeTab = sdk.id)}
-                            aria-pressed={activeTab === sdk.id}
                         >
                             <strong>{sdk.name}</strong>
                             <code>{sdk.install}</code>
@@ -331,7 +336,13 @@ $client->containers()->delete($c->id);`,
                                 type="button"
                                 class="copy-btn"
                                 onclick={() =>
-                                    copyToClipboard(sdk.install, sdk.id)}
+                                    copyToClipboard(
+                                        // Copy bare coordinates for Java (no parenthetical)
+                                        sdk.id === "java"
+                                            ? "io.pipeops:rexec:1.0.1"
+                                            : sdk.install,
+                                        sdk.id,
+                                    )}
                             >
                                 {copiedCommand === sdk.id ? "Copied" : "Copy"}
                             </button>
@@ -355,7 +366,7 @@ $client->containers()->delete($c->id);`,
 
         <section class="docs-section">
             <div class="section-head">
-                <h2>{activeSdk.name} example</h2>
+                <h2 id="sdk-example-heading">{activeSdk.name} example</h2>
                 <button
                     type="button"
                     class="copy-btn"
@@ -364,7 +375,30 @@ $client->containers()->delete($c->id);`,
                     {copiedCommand === "code" ? "Copied" : "Copy code"}
                 </button>
             </div>
-            <div class="code-block">
+            {#if activeSdk.id === "java"}
+                <p class="muted tip">
+                    Maven:
+                    <code
+                        >&lt;dependency&gt;…&lt;artifactId&gt;rexec&lt;/artifactId&gt;…&lt;/dependency&gt;</code
+                    >
+                    · Gradle:
+                    <code>implementation 'io.pipeops:rexec:1.0.1'</code>
+                </p>
+            {/if}
+            {#if activeSdk.id === "php"}
+                <p class="muted tip">
+                    If Packagist is not linked yet:
+                    <code
+                        >composer config repositories.rexec-php vcs https://github.com/PipeOpsHQ/rexec-php</code
+                    >
+                </p>
+            {/if}
+            <div
+                class="code-block"
+                role="tabpanel"
+                id="sdk-example-panel"
+                aria-labelledby={`sdk-tab-${activeSdk.id}`}
+            >
                 <div class="code-toolbar">
                     <span class="code-label">{activeSdk.id}</span>
                 </div>
@@ -601,6 +635,8 @@ $client->containers()->delete($c->id);`,
 
     .sdk-row.active {
         border-color: var(--accent);
+        /* Fallback for browsers without color-mix (e.g. Safari < 16.2) */
+        box-shadow: 0 0 0 1px rgba(0, 212, 255, 0.35);
         box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
     }
 
@@ -651,6 +687,8 @@ $client->containers()->delete($c->id);`,
 
     .link-btn:hover {
         text-decoration: none;
+        border-color: rgba(0, 212, 255, 0.4);
+        background: rgba(0, 212, 255, 0.08);
         border-color: color-mix(in srgb, var(--accent) 40%, transparent);
         background: color-mix(in srgb, var(--accent) 8%, transparent);
     }
@@ -703,6 +741,7 @@ $client->containers()->delete($c->id);`,
         gap: 8px;
         padding: 8px 12px;
         border-bottom: 1px solid var(--border);
+        background: var(--bg-secondary);
         background: color-mix(in srgb, var(--bg) 55%, var(--bg-secondary));
     }
 
@@ -726,13 +765,16 @@ $client->containers()->delete($c->id);`,
         tab-size: 2;
     }
 
-    .code-block code {
-        background: transparent !important;
-        padding: 0 !important;
-        color: inherit !important;
-        font-size: inherit !important;
-        white-space: inherit !important;
+    /* Higher specificity than section-level code styles — avoid !important */
+    .docs-section .code-block pre code {
+        background: transparent;
+        padding: 0;
+        color: inherit;
+        font-size: inherit;
+        white-space: inherit;
         border-radius: 0;
+        word-break: normal;
+        overflow-wrap: normal;
     }
 
     .ref-list {

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -532,6 +532,247 @@ func (h *AuthHandler) OAuthExchange(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, gin.H{"error": "Use callback endpoint"})
 }
 
+// PipeOpsAssertRequest is a server-to-server identity bridge from PipeOps controller.
+// Auth: header X-PipeOps-Assert-Key must match env PIPEOPS_ASSERT_KEY,
+// or Authorization Bearer is treated as a PipeOps OAuth access token (userinfo).
+type PipeOpsAssertRequest struct {
+	Email              string `json:"email"`
+	PipeOpsID          string `json:"pipeops_id"`
+	Username           string `json:"username,omitempty"`
+	FirstName          string `json:"first_name,omitempty"`
+	LastName           string `json:"last_name,omitempty"`
+	Avatar             string `json:"avatar,omitempty"`
+	EmailVerified      bool   `json:"email_verified"`
+	SubscriptionActive bool   `json:"subscription_active"`
+	// MintAPIToken also returns a short-lived rexec_… API token for SDKs/embed.
+	MintAPIToken bool `json:"mint_api_token,omitempty"`
+	// APITokenExpiresInDays defaults to 1 when minting (Rexec token API unit is days).
+	APITokenExpiresInDays *int `json:"api_token_expires_in_days,omitempty"`
+}
+
+// PipeOpsAssert find-or-creates a Rexec user from a verified PipeOps identity
+// (same email as Login-with-PipeOps OAuth) and returns a Rexec JWT.
+// Used by PipeOps BFF so sandboxes are owned by the human user, not the platform service token.
+func (h *AuthHandler) PipeOpsAssert(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var req PipeOpsAssertRequest
+	// Mode A: shared secret (PipeOps controller → Rexec)
+	assertKey := strings.TrimSpace(os.Getenv("PIPEOPS_ASSERT_KEY"))
+	providedKey := strings.TrimSpace(c.GetHeader("X-PipeOps-Assert-Key"))
+	usedSecret := assertKey != "" && providedKey != "" && subtleConstantTimeEq(assertKey, providedKey)
+
+	if usedSecret {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body", "message": "email and pipeops_id required"})
+			return
+		}
+	} else {
+		// Mode B: PipeOps OAuth access token → userinfo
+		authHeader := c.GetHeader("Authorization")
+		if !strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error":   "unauthorized",
+				"message": "require X-PipeOps-Assert-Key or Bearer PipeOps access token",
+			})
+			return
+		}
+		accessToken := strings.TrimSpace(authHeader[7:])
+		userInfo, err := h.oauthService.GetUserInfo(accessToken)
+		if err != nil {
+			log.Printf("[Auth] PipeOpsAssert userinfo failed: %v", err)
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_pipeops_token", "message": "failed to validate PipeOps token"})
+			return
+		}
+		req = PipeOpsAssertRequest{
+			Email:              userInfo.Email,
+			PipeOpsID:          fmt.Sprintf("%d", userInfo.ID),
+			Username:           userInfo.Username,
+			FirstName:          userInfo.FirstName,
+			LastName:           userInfo.LastName,
+			Avatar:             userInfo.Avatar,
+			EmailVerified:      userInfo.Verified,
+			SubscriptionActive: userInfo.SubscriptionActive,
+		}
+		// Allow body to request mint_api_token without overriding identity
+		var bodyOpts struct {
+			MintAPIToken          bool `json:"mint_api_token"`
+			APITokenExpiresInDays *int `json:"api_token_expires_in_days"`
+		}
+		_ = c.ShouldBindJSON(&bodyOpts)
+		req.MintAPIToken = bodyOpts.MintAPIToken
+		req.APITokenExpiresInDays = bodyOpts.APITokenExpiresInDays
+	}
+
+	normalizedEmail := strings.ToLower(strings.TrimSpace(req.Email))
+	if normalizedEmail == "" || !strings.Contains(normalizedEmail, "@") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "email_required"})
+		return
+	}
+	// Refuse to link unverified emails when using secret mode (caller must assert truth).
+	if usedSecret && !req.EmailVerified {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":   "email_not_verified",
+			"message": "only verified PipeOps emails can be asserted",
+		})
+		return
+	}
+
+	user, created, err := h.ensureUserFromPipeOps(ctx, &req, normalizedEmail)
+	if err != nil {
+		log.Printf("[Auth] PipeOpsAssert ensure user: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve user"})
+		return
+	}
+
+	sessionID, err := h.createUserSession(c, user)
+	if err != nil {
+		log.Printf("[Auth] PipeOpsAssert session: %v", err)
+		sessionID = ""
+	}
+	jwtToken, err := h.generateToken(user, sessionID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to mint jwt"})
+		return
+	}
+
+	// Default JWT TTL advertised to clients (matches generateToken default for non-guest)
+	expiresIn := int((90 * 24 * time.Hour).Seconds())
+	if user.SessionDurationMinutes > 0 {
+		expiresIn = user.SessionDurationMinutes * 60
+	}
+
+	resp := gin.H{
+		"token":       jwtToken,
+		"token_type":  "Bearer",
+		"expires_in":  expiresIn,
+		"user_id":     user.ID,
+		"email":       user.Email,
+		"username":    user.Username,
+		"pipeops_id":  user.PipeOpsID,
+		"tier":        user.Tier,
+		"created":     created,
+		"token_kind":  "jwt",
+	}
+
+	if req.MintAPIToken {
+		days := 1
+		if req.APITokenExpiresInDays != nil && *req.APITokenExpiresInDays > 0 {
+			days = *req.APITokenExpiresInDays
+		}
+		exp := time.Now().AddDate(0, 0, days)
+		name := fmt.Sprintf("pipeops-assert-%d", time.Now().Unix())
+		_, plain, tokenErr := h.store.GenerateAPIToken(ctx, user.ID, name, []string{"read", "write"}, &exp)
+		if tokenErr != nil {
+			log.Printf("[Auth] PipeOpsAssert mint API token: %v", tokenErr)
+		} else {
+			resp["api_token"] = plain
+			resp["api_token_expires_at"] = exp.UTC().Format(time.RFC3339)
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+func subtleConstantTimeEq(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var v byte
+	for i := 0; i < len(a); i++ {
+		v |= a[i] ^ b[i]
+	}
+	return v == 0
+}
+
+// ensureUserFromPipeOps mirrors OAuthCallback user provisioning (email match).
+func (h *AuthHandler) ensureUserFromPipeOps(ctx context.Context, req *PipeOpsAssertRequest, normalizedEmail string) (*models.User, bool, error) {
+	user, _, err := h.store.GetUserByEmail(ctx, normalizedEmail)
+	if err != nil {
+		return nil, false, err
+	}
+
+	pipeopsID := strings.TrimSpace(req.PipeOpsID)
+	username := strings.TrimSpace(req.Username)
+	if username == "" {
+		username = strings.TrimSpace(req.FirstName)
+	}
+	if username == "" {
+		// Local-part of email
+		if i := strings.Index(normalizedEmail, "@"); i > 0 {
+			username = normalizedEmail[:i]
+		} else {
+			username = normalizedEmail
+		}
+	}
+
+	tier := "free"
+	if req.SubscriptionActive {
+		tier = "pro"
+	}
+
+	if user == nil {
+		user = &models.User{
+			ID:                 uuid.New().String(),
+			Email:              normalizedEmail,
+			Username:           username,
+			FirstName:          req.FirstName,
+			LastName:           req.LastName,
+			Avatar:             req.Avatar,
+			Verified:           true, // only verified emails allowed via assert
+			SubscriptionActive: req.SubscriptionActive,
+			Tier:               tier,
+			PipeOpsID:          pipeopsID,
+			CreatedAt:          time.Now(),
+			UpdatedAt:          time.Now(),
+			IsAdmin:            false,
+		}
+		if err := h.store.CreateUser(ctx, user, ""); err != nil {
+			return nil, false, err
+		}
+		if h.adminEventsHub != nil {
+			h.adminEventsHub.Broadcast("user_created", user)
+		}
+		return user, true, nil
+	}
+
+	// Existing user — sync PipeOps linkage and profile
+	user.FirstName = firstNonEmptyStr(req.FirstName, user.FirstName)
+	user.LastName = firstNonEmptyStr(req.LastName, user.LastName)
+	user.Avatar = firstNonEmptyStr(req.Avatar, user.Avatar)
+	if req.EmailVerified {
+		user.Verified = true
+	}
+	user.SubscriptionActive = req.SubscriptionActive
+	if req.SubscriptionActive {
+		if user.Tier != "pro" && user.Tier != "enterprise" {
+			user.Tier = "pro"
+		}
+	} else if user.Tier == "guest" {
+		user.Tier = "free"
+	}
+	if user.PipeOpsID == "" && pipeopsID != "" {
+		user.PipeOpsID = pipeopsID
+	}
+	user.UpdatedAt = time.Now()
+	if err := h.store.UpdateUser(ctx, user); err != nil {
+		log.Printf("[Auth] PipeOpsAssert update user %s: %v", user.ID, err)
+	}
+	if h.adminEventsHub != nil {
+		h.adminEventsHub.Broadcast("user_updated", user)
+	}
+	return user, false, nil
+}
+
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
 // createUserSession records a new login session and returns its ID.
 // If session tracking fails, caller may choose to proceed without a session ID.
 // If single_session_mode is enabled, this will revoke all other sessions first.


### PR DESCRIPTION
## Summary
Fixes visual/copy glitches on the in-app **Rexec SDKs** page (`/docs/sdk`):

- Replace raw \`SDK_GETTING_STARTED.md\` / \`SDK.md\` link labels with **Quick start** / **API reference**
- Add missing \`.muted\` styles
- Fix invalid \`rgba(var(--accent-rgb, …))\` active-row CSS
- Split install caveats into clear callouts (images / create / exec)
- Code blocks with toolbar + copy; better wrap for long install commands
- Sandbox wording + PipeOps sandboxes doc link

## Test plan
- [ ] Open \`/docs/sdk\`
- [ ] Auth snippet copies correctly; multi-line curl readable
- [ ] Select each language row; example updates; copy works
- [ ] Links open GitHub / PipeOps docs with sensible labels
- [ ] Mobile: rows stack cleanly