### PR TITLE
fix(auth): do not screen-lock PipeOps assert / sid-less JWTs

### DIFF
--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -625,10 +625,18 @@ func (h *AuthHandler) PipeOpsAssert(c *gin.Context) {
 		return
 	}
 
-	sessionID, err := h.createUserSession(c, user)
-	if err != nil {
-		log.Printf("[Auth] PipeOpsAssert session: %v", err)
-		sessionID = ""
+	// Server-to-server (shared secret) asserts are for PipeOps BFF / automation.
+	// Do not create a browser session (sid) — session JWTs hit screen-lock (423
+	// session_locked) after the user locks rexec.sh, which breaks the BFF.
+	// Prefer mint_api_token (rexec_*) which already bypasses screen lock.
+	sessionID := ""
+	if !usedSecret {
+		sid, sessErr := h.createUserSession(c, user)
+		if sessErr != nil {
+			log.Printf("[Auth] PipeOpsAssert session: %v", sessErr)
+		} else {
+			sessionID = sid
+		}
 	}
 	jwtToken, err := h.generateToken(user, sessionID)
 	if err != nil {

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -321,7 +321,10 @@ func AuthMiddleware(store *storage.PostgresStore, mfaService *auth.MFAService, j
 
 		// --- Server-enforced screen lock ---
 		// If the account is locked after this token was issued, block access with 423.
-		if user.ScreenLockEnabled && user.ScreenLockHash != "" && user.LockRequiredSince != nil {
+		// API tokens (rexec_*) already return early above and never hit this path.
+		// Only enforce for browser sessions (JWT with sid). Automation JWTs without
+		// a session id must keep working for BFF/agent use after screen lock.
+		if sessionID != "" && user.ScreenLockEnabled && user.ScreenLockHash != "" && user.LockRequiredSince != nil {
 			// Allow unlock endpoint to proceed even with a locked token.
 			if c.Request.URL.Path != "/api/security/unlock" {
 				tokenIat := time.Unix(int64(iat), 0)


### PR DESCRIPTION
## Summary
PipeOps BFF was failing with `rexec api 423: session_locked` after users locked their Rexec screen.

- Apply screen lock only when the JWT has a browser `sid`
- Server-to-server PipeOps assert skips creating a browser session

API tokens (`rexec_*`) already bypassed screen lock; assert now aligns with automation use.

## Test plan
- [ ] Lock screen on rexec.sh, then open a sandbox terminal from PipeOps (with assert + API token path)
- [ ] Browser login + screen lock still blocks UI until unlock