### PR TITLE
fix(sandbox): set public DNS on container create

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ CONTAINER_NETWORK=rexec-network
 CONTAINER_IDLE_TIMEOUT=3600
 # DNS servers injected into every sandbox (comma-separated IPs).
 # Defaults to 8.8.8.8,1.1.1.1 so apt/curl work when the host resolver is loopback-only.
+# For isolation / compliance, point this at your own resolvers instead of public DNS.
 # CONTAINER_DNS=8.8.8.8,1.1.1.1
 
 

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ DOCKER_HOST=unix:///var/run/docker.sock
 VOLUME_PATH=/var/lib/rexec/volumes
 CONTAINER_NETWORK=rexec-network
 CONTAINER_IDLE_TIMEOUT=3600
+# DNS servers injected into every sandbox (comma-separated IPs).
+# Defaults to 8.8.8.8,1.1.1.1 so apt/curl work when the host resolver is loopback-only.
+# CONTAINER_DNS=8.8.8.8,1.1.1.1
+
 
 # Resource Limits (defaults)
 DEFAULT_MEMORY_MB=512

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -26,16 +26,24 @@ const IsolatedNetworkName = "rexec-isolated"
 
 // defaultContainerDNS is used when CONTAINER_DNS is unset so sandboxes do not
 // inherit a broken host resolver (e.g. systemd-resolved stub 127.0.0.53).
+//
+// Operators with network-isolation / data-residency requirements should set
+// CONTAINER_DNS to internal resolvers (or resolvers they control) instead of
+// relying on these public defaults.
 const defaultContainerDNS = "8.8.8.8,1.1.1.1"
 
-// sandboxDNSServers returns DNS servers for new containers.
-// Override with CONTAINER_DNS (comma-separated IPs), e.g. "8.8.8.8,1.1.1.1".
-func sandboxDNSServers() []netip.Addr {
+// parseSandboxDNS parses CONTAINER_DNS (or the public default). Call once at
+// manager startup so invalid entries are logged only once.
+//
+// Type is []netip.Addr because github.com/moby/moby/api HostConfig.DNS uses
+// that type (not []string) as of api v1.54.
+func parseSandboxDNS() []netip.Addr {
 	raw := strings.TrimSpace(os.Getenv("CONTAINER_DNS"))
 	if raw == "" {
 		raw = defaultContainerDNS
 	}
 	var out []netip.Addr
+	var invalid []string
 	for _, part := range strings.Split(raw, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -43,10 +51,13 @@ func sandboxDNSServers() []netip.Addr {
 		}
 		addr, err := netip.ParseAddr(part)
 		if err != nil {
-			log.Printf("[Container] WARNING: ignoring invalid DNS server %q: %v", part, err)
+			invalid = append(invalid, part)
 			continue
 		}
 		out = append(out, addr)
+	}
+	if len(invalid) > 0 {
+		log.Printf("[Container] WARNING: ignoring invalid CONTAINER_DNS entries %q (use comma-separated IPs)", strings.Join(invalid, ","))
 	}
 	if len(out) == 0 {
 		// Hard fallback if env was only invalid values
@@ -590,6 +601,8 @@ type Manager struct {
 	diskQuotaCheckMu  sync.Once
 	availableRuntimes []string
 	runtimeCheckMu    sync.Once
+	// dnsServers is resolved once at NewManager (from CONTAINER_DNS or defaults).
+	dnsServers []netip.Addr
 
 	// Stats broadcasting
 	activeStatsStreams map[string]*StatsBroadcaster
@@ -671,6 +684,9 @@ func NewManager(volumePaths ...string) (*Manager, error) {
 		volumePath = volumePaths[0]
 	}
 
+	dnsServers := parseSandboxDNS()
+	log.Printf("[Container] Sandbox DNS servers: %v (override with CONTAINER_DNS)", dnsServers)
+
 	mgr := &Manager{
 		client:             cli,
 		containers:         make(map[string]*ContainerInfo),
@@ -678,6 +694,7 @@ func NewManager(volumePaths ...string) (*Manager, error) {
 		volumePath:         volumePath,
 		diskQuotaEnabled:   false,
 		diskQuotaChecked:   false,
+		dnsServers:         dnsServers,
 		activeStatsStreams: make(map[string]*StatsBroadcaster),
 	}
 
@@ -696,6 +713,16 @@ func NewManager(volumePaths ...string) (*Manager, error) {
 func (m *Manager) checkHostCapabilities() {
 	m.checkRuntimeSupport()
 	m.checkDiskQuotaSupport()
+}
+
+// dnsForCreate returns DNS servers for HostConfig.
+// Prefer the value resolved at NewManager; fall back to parse for partial
+// Manager values used in unit tests.
+func (m *Manager) dnsForCreate() []netip.Addr {
+	if m != nil && len(m.dnsServers) > 0 {
+		return m.dnsServers
+	}
+	return parseSandboxDNS()
 }
 
 // ensureIsolatedNetwork ensures the isolated network exists with ICC disabled
@@ -1286,11 +1313,10 @@ func (m *Manager) CreateContainer(ctx context.Context, cfg ContainerConfig) (*Co
 		},
 		// Port bindings (optional, for future use)
 		PortBindings: network.PortMap{},
-		// Explicit public DNS so apt/curl work even when the Docker host
-		// only has a loopback resolver (common cause of
-		// "Temporary failure resolving 'archive.ubuntu.com'").
-		// Override via CONTAINER_DNS env (comma-separated IPs).
-		DNS: sandboxDNSServers(),
+		// Explicit DNS so apt/curl work even when the Docker host only has a
+		// loopback resolver. HostConfig.DNS is []netip.Addr (moby/api).
+		// Defaults / CONTAINER_DNS are resolved once in NewManager.
+		DNS: m.dnsForCreate(),
 	}
 
 	// Special handling for macOS (CUA Lumier / docker-osx style VM images)

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/netip"
 	"os"
 	"runtime"
 	"strconv"
@@ -22,6 +23,39 @@ import (
 )
 
 const IsolatedNetworkName = "rexec-isolated"
+
+// defaultContainerDNS is used when CONTAINER_DNS is unset so sandboxes do not
+// inherit a broken host resolver (e.g. systemd-resolved stub 127.0.0.53).
+const defaultContainerDNS = "8.8.8.8,1.1.1.1"
+
+// sandboxDNSServers returns DNS servers for new containers.
+// Override with CONTAINER_DNS (comma-separated IPs), e.g. "8.8.8.8,1.1.1.1".
+func sandboxDNSServers() []netip.Addr {
+	raw := strings.TrimSpace(os.Getenv("CONTAINER_DNS"))
+	if raw == "" {
+		raw = defaultContainerDNS
+	}
+	var out []netip.Addr
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		addr, err := netip.ParseAddr(part)
+		if err != nil {
+			log.Printf("[Container] WARNING: ignoring invalid DNS server %q: %v", part, err)
+			continue
+		}
+		out = append(out, addr)
+	}
+	if len(out) == 0 {
+		// Hard fallback if env was only invalid values
+		a, _ := netip.ParseAddr("8.8.8.8")
+		b, _ := netip.ParseAddr("1.1.1.1")
+		return []netip.Addr{a, b}
+	}
+	return out
+}
 
 // ProgressEvent represents a progress update during container creation
 type ProgressEvent struct {
@@ -1252,6 +1286,11 @@ func (m *Manager) CreateContainer(ctx context.Context, cfg ContainerConfig) (*Co
 		},
 		// Port bindings (optional, for future use)
 		PortBindings: network.PortMap{},
+		// Explicit public DNS so apt/curl work even when the Docker host
+		// only has a loopback resolver (common cause of
+		// "Temporary failure resolving 'archive.ubuntu.com'").
+		// Override via CONTAINER_DNS env (comma-separated IPs).
+		DNS: sandboxDNSServers(),
 	}
 
 	// Special handling for macOS (CUA Lumier / docker-osx style VM images)

--- a/internal/container/manager_runtime_test.go
+++ b/internal/container/manager_runtime_test.go
@@ -2,11 +2,42 @@ package container
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 )
+
+func TestSandboxDNSServers_Default(t *testing.T) {
+	t.Setenv("CONTAINER_DNS", "")
+	got := sandboxDNSServers()
+	want := []string{"8.8.8.8", "1.1.1.1"}
+	if len(got) != len(want) {
+		t.Fatalf("len(dns)=%d, want %d (%v)", len(got), len(want), got)
+	}
+	for i, addr := range got {
+		if addr.String() != want[i] {
+			t.Errorf("dns[%d]=%s, want %s", i, addr.String(), want[i])
+		}
+	}
+}
+
+func TestSandboxDNSServers_Override(t *testing.T) {
+	t.Setenv("CONTAINER_DNS", "9.9.9.9, 208.67.222.222")
+	got := sandboxDNSServers()
+	if len(got) != 2 || got[0].String() != "9.9.9.9" || got[1].String() != "208.67.222.222" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestSandboxDNSServers_InvalidFallsBack(t *testing.T) {
+	t.Setenv("CONTAINER_DNS", "not-an-ip,also-bad")
+	got := sandboxDNSServers()
+	if len(got) != 2 || got[0].String() != "8.8.8.8" {
+		t.Fatalf("expected hard fallback, got %v", got)
+	}
+}
 
 func TestManagerCreateContainerRuntimeSelection(t *testing.T) {
 	tests := []struct {
@@ -59,9 +90,11 @@ func TestManagerCreateContainerRuntimeSelection(t *testing.T) {
 				}, nil
 			}
 
+			var gotDNS []netip.Addr
 			mockClient.ContainerCreateFunc = func(ctx context.Context, options client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 				gotRuntime = options.HostConfig.Runtime
 				gotStorageSize = options.HostConfig.StorageOpt["size"]
+				gotDNS = options.HostConfig.DNS
 				return client.ContainerCreateResult{ID: "test-container-id"}, nil
 			}
 
@@ -90,6 +123,13 @@ func TestManagerCreateContainerRuntimeSelection(t *testing.T) {
 
 			if gotStorageSize != tt.wantStorageSize {
 				t.Fatalf("storage size = %q, want %q", gotStorageSize, tt.wantStorageSize)
+			}
+
+			if len(gotDNS) == 0 {
+				t.Fatal("expected HostConfig.DNS to be set")
+			}
+			if gotDNS[0].String() != "8.8.8.8" {
+				t.Fatalf("dns[0]=%s, want 8.8.8.8", gotDNS[0].String())
 			}
 		})
 	}

--- a/internal/container/manager_runtime_test.go
+++ b/internal/container/manager_runtime_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/moby/moby/client"
 )
 
-func TestSandboxDNSServers_Default(t *testing.T) {
+func TestParseSandboxDNS_Default(t *testing.T) {
 	t.Setenv("CONTAINER_DNS", "")
-	got := sandboxDNSServers()
+	got := parseSandboxDNS()
 	want := []string{"8.8.8.8", "1.1.1.1"}
 	if len(got) != len(want) {
 		t.Fatalf("len(dns)=%d, want %d (%v)", len(got), len(want), got)
@@ -23,19 +23,31 @@ func TestSandboxDNSServers_Default(t *testing.T) {
 	}
 }
 
-func TestSandboxDNSServers_Override(t *testing.T) {
+func TestParseSandboxDNS_Override(t *testing.T) {
 	t.Setenv("CONTAINER_DNS", "9.9.9.9, 208.67.222.222")
-	got := sandboxDNSServers()
+	got := parseSandboxDNS()
 	if len(got) != 2 || got[0].String() != "9.9.9.9" || got[1].String() != "208.67.222.222" {
 		t.Fatalf("got %v", got)
 	}
 }
 
-func TestSandboxDNSServers_InvalidFallsBack(t *testing.T) {
+func TestParseSandboxDNS_InvalidFallsBack(t *testing.T) {
 	t.Setenv("CONTAINER_DNS", "not-an-ip,also-bad")
-	got := sandboxDNSServers()
+	got := parseSandboxDNS()
 	if len(got) != 2 || got[0].String() != "8.8.8.8" {
 		t.Fatalf("expected hard fallback, got %v", got)
+	}
+}
+
+func TestManagerDNSForCreate_UsesCached(t *testing.T) {
+	custom, err := netip.ParseAddr("9.9.9.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{dnsServers: []netip.Addr{custom}}
+	got := m.dnsForCreate()
+	if len(got) != 1 || got[0].String() != "9.9.9.9" {
+		t.Fatalf("got %v, want [9.9.9.9]", got)
 	}
 }
 
@@ -75,10 +87,13 @@ func TestManagerCreateContainerRuntimeSelection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("OCI_RUNTIME", tt.requestedRuntime)
+			// Isolate DNS from other subtests / host env
+			t.Setenv("CONTAINER_DNS", "8.8.8.8,1.1.1.1")
 
 			mockClient := &MockDockerClient{}
 			var gotRuntime string
 			var gotStorageSize string
+			var gotDNS []netip.Addr
 
 			mockClient.ContainerInspectFunc = func(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
 				return client.ContainerInspectResult{
@@ -90,11 +105,10 @@ func TestManagerCreateContainerRuntimeSelection(t *testing.T) {
 				}, nil
 			}
 
-			var gotDNS []netip.Addr
 			mockClient.ContainerCreateFunc = func(ctx context.Context, options client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
 				gotRuntime = options.HostConfig.Runtime
 				gotStorageSize = options.HostConfig.StorageOpt["size"]
-				gotDNS = options.HostConfig.DNS
+				gotDNS = append([]netip.Addr(nil), options.HostConfig.DNS...)
 				return client.ContainerCreateResult{ID: "test-container-id"}, nil
 			}
 
@@ -105,6 +119,7 @@ func TestManagerCreateContainerRuntimeSelection(t *testing.T) {
 				diskQuotaEnabled:  true,
 				diskQuotaChecked:  true,
 				availableRuntimes: []string{"runc", "runsc"},
+				dnsServers:        parseSandboxDNS(),
 			}
 
 			_, err := manager.CreateContainer(context.Background(), ContainerConfig{


### PR DESCRIPTION
## Summary

- Set explicit DNS (`8.8.8.8`, `1.1.1.1`) on sandbox container create so packages (`apt-get update`, etc.) resolve hostnames.
- Avoids inheriting a broken host-only resolver (common with systemd-resolved / `127.0.0.53`).
- Optional override via `CONTAINER_DNS` (comma-separated IPs); documented in `.env.example`.
- Unit tests for default, override, invalid fallback, and create-path DNS.

## Context

Users hit:

```text
Temporary failure resolving 'archive.ubuntu.com'
```

inside Ubuntu sandboxes right after create. Network attach is `rexec-isolated` with no `HostConfig.DNS`.

## Test plan

- [x] `go test ./internal/container/ -run 'TestSandboxDNSServers|TestManagerCreateContainerRuntimeSelection'`
- [ ] Deploy and create a **new** Ubuntu sandbox
- [ ] Inside sandbox: `cat /etc/resolv.conf` shows public nameservers (or Docker embeds them via 127.0.0.11 → those upstreams)
- [ ] `apt-get update` succeeds
- [ ] Existing sandboxes unchanged until recreate