### PR TITLE
ci: use go.mod for Go version in CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
+          cache: true
       - name: Run Tests
+        env:
+          GOTOOLCHAIN: auto
         run: go test -v ./...
 
   test-frontend:
@@ -80,7 +83,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
+          cache: true
 
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           cache: true
 
       - name: Download dependencies


### PR DESCRIPTION
## Summary

- Backend CI was failing: `go.mod requires go >= 1.26.1 (running go 1.24.13)`.
- `ci.yml` and `release.yml` now use `go-version-file: go.mod` instead of hard-coded 1.24/1.22.
- Test step sets `GOTOOLCHAIN: auto` so the toolchain can match `go.mod`.

## Test plan

- [ ] PR checks: **Test Backend** should pass (or at least get past setup-go / module download)
- [ ] Frontend still green

## Deploy checklist (post #89)

After this lands and you deploy `main` with the agent sandbox surface:

1. **Deploy API** build from `main` (Dockerfile already on `golang:1.26-alpine`).
2. **Restart** so migrations create `sandbox_templates` / `sandbox_snapshots`.
3. Optional env:
   - `WARM_POOL=ubuntu:2`
   - `RESTRICTED_EGRESS_PROXY_ADDR=:13128`
   - `CONTAINER_DNS=8.8.8.8,1.1.1.1` (defaults already)
4. **MCP** (optional): `cd sdk/js && npm run build && cd ../mcp && npm i && npm run build`
5. Smoke: create sandbox → `POST .../exec` → snapshot/fork as needed.