### PR TITLE
chore(sdk): bump packages to 1.2.0 for publish

### DIFF
--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -8,7 +8,7 @@ Official client libraries for the Rexec **sandbox** API (files and terminals).
 |--|--|
 | **Hosted base URL** | `https://rexec.sh` |
 | **Auth header** | `Authorization: Bearer <token>` |
-| **SDK version** | **v1.1.0** |
+| **SDK version** | **v1.2.0** |
 | **Quick start** | [SDK_GETTING_STARTED.md](SDK_GETTING_STARTED.md) |
 | **Publishing** | [SDK_PUBLISHING.md](SDK_PUBLISHING.md) |
 | **Source monorepo** | [github.com/PipeOpsHQ/Rexec](https://github.com/PipeOpsHQ/Rexec) (`sdk/{js,python,go,rust,ruby,dotnet,java,php}`) |
@@ -38,17 +38,17 @@ Typical use cases: AI agents running code safely, ephemeral dev shells, demos, a
 
 ---
 
-## Available SDKs (v1.1.0)
+## Available SDKs (v1.2.0)
 
 | Language | Package / module | Install | Import notes |
 |----------|------------------|---------|--------------|
 | **JS / TS** | [pipeops-rexec](https://www.npmjs.com/package/pipeops-rexec) | `npm install pipeops-rexec` | `import { RexecClient } from 'pipeops-rexec'` |
 | **Python** | [pipeops-rexec](https://pypi.org/project/pipeops-rexec/) | `pip install pipeops-rexec` | `from rexec import RexecClient` |
-| **Go** | [github.com/PipeOpsHQ/rexec-go](https://github.com/PipeOpsHQ/rexec-go) | `go get github.com/PipeOpsHQ/rexec-go@v1.1.0` | `import rexec "github.com/PipeOpsHQ/rexec-go"` |
+| **Go** | [github.com/PipeOpsHQ/rexec-go](https://github.com/PipeOpsHQ/rexec-go) | `go get github.com/PipeOpsHQ/rexec-go@v1.2.0` | `import rexec "github.com/PipeOpsHQ/rexec-go"` |
 | **Rust** | [pipeops-rexec](https://crates.io/crates/pipeops-rexec) | `cargo add pipeops-rexec` | `use rexec::{…}` (crate name ≠ import name) |
 | **Ruby** | [pipeops-rexec](https://rubygems.org/gems/pipeops-rexec) | `gem install pipeops-rexec` | `require "rexec"` |
 | **C# / .NET** | [PipeOps.Rexec](https://www.nuget.org/packages/PipeOps.Rexec) | `dotnet add package PipeOps.Rexec` | `using Rexec;` |
-| **Java / Kotlin** | `io.pipeops:rexec:1.1.0` | Maven/Gradle | `import io.pipeops.rexec.*` |
+| **Java / Kotlin** | `io.pipeops:rexec:1.2.0` | Maven/Gradle | `import io.pipeops.rexec.*` |
 | **PHP** | [pipeopshq/rexec](https://packagist.org/packages/pipeopshq/rexec) | `composer require pipeopshq/rexec` | `use Rexec\RexecClient` |
 
 Publishing is **GitHub Actions only** — see [SDK_PUBLISHING.md](SDK_PUBLISHING.md).
@@ -571,7 +571,7 @@ asyncio.run(main())
 ### Go
 
 ```bash
-go get github.com/PipeOpsHQ/rexec-go@v1.1.0
+go get github.com/PipeOpsHQ/rexec-go@v1.2.0
 ```
 
 ```go
@@ -686,7 +686,7 @@ await client.Sandboxes.DeleteAsync(c.Id);
 <dependency>
   <groupId>io.pipeops</groupId>
   <artifactId>rexec</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
 </dependency>
 ```
 
@@ -714,7 +714,7 @@ client.sandboxes().delete(c.id)
 ```
 
 Install from source: `cd sdk/java && mvn install -DskipTests`.  
-Maven Central coordinates: `io.pipeops:rexec:1.1.0` · [repo path](https://repo1.maven.org/maven2/io/pipeops/rexec/).
+Maven Central coordinates: `io.pipeops:rexec:1.2.0` · [repo path](https://repo1.maven.org/maven2/io/pipeops/rexec/).
 
 ### PHP
 

--- a/docs/SDK_GETTING_STARTED.md
+++ b/docs/SDK_GETTING_STARTED.md
@@ -165,7 +165,7 @@ asyncio.run(main())
 <summary>Go</summary>
 
 ```bash
-go get github.com/PipeOpsHQ/rexec-go@v1.1.0
+go get github.com/PipeOpsHQ/rexec-go@v1.2.0
 ```
 
 ```go

--- a/sdk/dotnet/Rexec.csproj
+++ b/sdk/dotnet/Rexec.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>PipeOps.Rexec</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>PipeOpsHQ</Authors>
     <Company>PipeOps</Company>
     <Description>Official .NET SDK for Rexec — AI-native sandboxes</Description>

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.pipeops</groupId>
     <artifactId>rexec</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>Rexec Java SDK</name>

--- a/sdk/java/src/main/java/io/pipeops/rexec/RexecClient.java
+++ b/sdk/java/src/main/java/io/pipeops/rexec/RexecClient.java
@@ -63,7 +63,7 @@ public class RexecClient {
                     Request.Builder builder = original.newBuilder()
                             .header("Authorization", "Bearer " + token)
                             .header("Accept", "application/json")
-                            .header("User-Agent", "pipeops-rexec-java/1.1.0");
+                            .header("User-Agent", "pipeops-rexec-java/1.2.0");
                     return chain.proceed(builder.build());
                 })
                 .build();

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeops-rexec",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Official JavaScript/TypeScript SDK for Rexec — AI-native sandboxes",
   "type": "module",
   "main": "dist/index.js",

--- a/sdk/mcp/package.json
+++ b/sdk/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipeops/rexec-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "MCP server for Rexec — AI agent tools for sandboxes (create, exec, files, templates)",
   "type": "module",
   "bin": {

--- a/sdk/php/src/RexecClient.php
+++ b/sdk/php/src/RexecClient.php
@@ -46,7 +46,7 @@ class RexecClient
                 'Authorization' => 'Bearer ' . $token,
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
-                'User-Agent' => 'pipeops-rexec-php/1.1.0',
+                'User-Agent' => 'pipeops-rexec-php/1.2.0',
             ],
         ];
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pipeops-rexec"
-version = "1.1.0"
+version = "1.2.0"
 description = "Official Python SDK for Rexec — AI-native sandboxes"
 readme = "README.md"
 license = "MIT"

--- a/sdk/python/rexec/__init__.py
+++ b/sdk/python/rexec/__init__.py
@@ -29,7 +29,7 @@ from rexec.exceptions import RexecError, RexecAPIError, RexecConnectionError
 from rexec.files import FileInfo, FileService
 from rexec.terminal import Terminal, TerminalService
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __all__ = [
     "RexecClient",
     "Sandbox",

--- a/sdk/ruby/lib/rexec/version.rb
+++ b/sdk/ruby/lib/rexec/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rexec
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/sdk/ruby/rexec.gemspec
+++ b/sdk/ruby/rexec.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "pipeops-rexec"
-  spec.version = "1.1.0"
+  spec.version = "1.2.0"
   spec.authors = ["PipeOpsHQ"]
   spec.email = ["support@pipeops.io"]
 

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -766,7 +766,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pipeops-rexec"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "futures-util",
  "reqwest",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipeops-rexec"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 authors = ["PipeOpsHQ <support@pipeops.io>"]
 description = "Official Rust SDK for Rexec — AI-native sandboxes"


### PR DESCRIPTION
## Summary

- Bump monorepo SDK package versions to **1.2.0** so publish jobs ship the post-#89 agent surface (exec, templates, snapshots, network modes, etc.).
- Docs install pins updated to 1.2.0.
- MCP package version bumped (publish separately / with npm if configured).

## After merge

Run **Publish SDKs** workflow with `version=1.2.0`, `sdks=all`, and sync Go/PHP tags.