### PR TITLE
fix(security): harden port-forward HTTP proxy against SSRF

### DIFF
--- a/internal/api/handlers/portforward.go
+++ b/internal/api/handlers/portforward.go
@@ -7,7 +7,10 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -532,14 +535,17 @@ func (h *PortForwardHandler) HandleHTTPProxy(c *gin.Context) {
 		return
 	}
 
-	// Build target URL
-	targetURL := fmt.Sprintf("http://%s:%d%s", ipAddress, pf.ContainerPort, proxyPath)
-	if c.Request.URL.RawQuery != "" {
-		targetURL += "?" + c.Request.URL.RawQuery
+	// Build target URL with a fixed host (container IP:port). User input is only allowed
+	// as a sanitized path/query so it cannot rewrite the authority (SSRF / CodeQL go/request-forgery).
+	target, targetAddr, err := buildContainerProxyURL(ipAddress, pf.ContainerPort, proxyPath, c.Request.URL.RawQuery)
+	if err != nil {
+		log.Printf("Invalid proxy target for %s: %v", forwardID, err)
+		h.renderPortForwardError(c, "Bad Request", "The requested path is invalid.", pf.ContainerPort)
+		return
 	}
 
-	// Create proxy request
-	proxyReq, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, targetURL, c.Request.Body)
+	// Create proxy request against the validated container URL only.
+	proxyReq, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, target.String(), c.Request.Body)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create proxy request"})
 		return
@@ -572,11 +578,17 @@ func (h *PortForwardHandler) HandleHTTPProxy(c *gin.Context) {
 	proxyReq.Header.Set("X-Forwarded-Host", c.Request.Host)
 	proxyReq.Header.Set("X-Real-IP", c.ClientIP())
 
-	// Execute request
+	// Execute request: always dial the validated container address, never a URL-derived host.
 	client := &http.Client{
 		Timeout: 60 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse // Don't follow redirects, let client handle them
+		},
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				d := net.Dialer{Timeout: 30 * time.Second}
+				return d.DialContext(ctx, network, targetAddr)
+			},
 		},
 	}
 
@@ -600,6 +612,68 @@ func (h *PortForwardHandler) HandleHTTPProxy(c *gin.Context) {
 
 	// Stream response body
 	io.Copy(c.Writer, resp.Body)
+}
+
+// sanitizeProxyPath normalizes a reverse-proxy path so it cannot rewrite request authority
+// when used with url.URL{Host: ...}. Rejects scheme-relative paths and backslash authority tricks.
+func sanitizeProxyPath(p string) (string, error) {
+	if p == "" {
+		return "/", nil
+	}
+	// Backslash can act as a path separator / authority introducer in some HTTP stacks.
+	if strings.Contains(p, "\\") {
+		return "", fmt.Errorf("path must not contain backslashes")
+	}
+	// Scheme-relative paths (//host/...) must never be accepted as path input.
+	if strings.HasPrefix(p, "//") {
+		return "", fmt.Errorf("path must be a relative URL path")
+	}
+	// Absolute URIs belong in the host/scheme fields, not the path.
+	if strings.Contains(p, "://") && !strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("path must be a relative URL path")
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	cleaned := path.Clean(p)
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+	// path.Clean("//x") becomes "/x" on most Go versions; keep an explicit guard.
+	if strings.HasPrefix(cleaned, "//") {
+		return "", fmt.Errorf("path must be a relative URL path")
+	}
+	return cleaned, nil
+}
+
+// buildContainerProxyURL builds an HTTP URL whose host is exclusively the validated
+// container IP and port. User-controlled path/query cannot change the authority.
+// Returns the URL and the dial address (host:port) for a locked Transport dialer.
+func buildContainerProxyURL(ip string, port int, proxyPath, rawQuery string) (*url.URL, string, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return nil, "", fmt.Errorf("invalid container IP")
+	}
+	if port < 1 || port > 65535 {
+		return nil, "", fmt.Errorf("invalid container port")
+	}
+	cleanedPath, err := sanitizeProxyPath(proxyPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Host is derived only from the Docker-provided IP and stored port (already range-checked).
+	host := net.JoinHostPort(parsedIP.String(), strconv.Itoa(port))
+	u := &url.URL{
+		Scheme:   "http",
+		Host:     host,
+		Path:     cleanedPath,
+		RawQuery: rawQuery,
+	}
+	return u, host, nil
 }
 
 // renderPortForwardError renders a branded HTML error page for port forwarding

--- a/internal/api/handlers/portforward_test.go
+++ b/internal/api/handlers/portforward_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestSanitizeProxyPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty becomes root", in: "", want: "/"},
+		{name: "root", in: "/", want: "/"},
+		{name: "simple path", in: "/api/health", want: "/api/health"},
+		{name: "nested path", in: "/foo/bar/baz", want: "/foo/bar/baz"},
+		{name: "cleans dots", in: "/foo/../bar", want: "/bar"},
+		{name: "missing leading slash", in: "api/health", want: "/api/health"},
+		{name: "allows at-sign in path", in: "/@user/profile", want: "/@user/profile"},
+		{name: "allows scheme-like segment under root", in: "/redirect/https://evil.com", want: "/redirect/https:/evil.com"},
+		{name: "rejects absolute URI without leading slash", in: "http://evil.com/", wantErr: true},
+		{name: "rejects scheme relative", in: "//evil.com/path", wantErr: true},
+		{name: "rejects backslash", in: "/foo\\bar", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sanitizeProxyPath(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got path %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildContainerProxyURL(t *testing.T) {
+	t.Run("builds fixed host from container IP and port", func(t *testing.T) {
+		u, addr, err := buildContainerProxyURL("10.0.0.5", 3000, "/app", "q=1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if addr != "10.0.0.5:3000" {
+			t.Fatalf("addr = %q, want 10.0.0.5:3000", addr)
+		}
+		if u.Scheme != "http" {
+			t.Fatalf("scheme = %q", u.Scheme)
+		}
+		if u.Host != "10.0.0.5:3000" {
+			t.Fatalf("host = %q, want 10.0.0.5:3000", u.Host)
+		}
+		if u.Path != "/app" {
+			t.Fatalf("path = %q", u.Path)
+		}
+		if u.RawQuery != "q=1" {
+			t.Fatalf("query = %q", u.RawQuery)
+		}
+		// Host must not be influenced by path-like authority tricks in input.
+		if u.Hostname() != "10.0.0.5" {
+			t.Fatalf("hostname = %q", u.Hostname())
+		}
+	})
+
+	t.Run("ipv6 uses join host port form", func(t *testing.T) {
+		u, addr, err := buildContainerProxyURL("fd00::1", 8080, "/", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if addr != "[fd00::1]:8080" {
+			t.Fatalf("addr = %q", addr)
+		}
+		if u.Host != "[fd00::1]:8080" {
+			t.Fatalf("host = %q", u.Host)
+		}
+	})
+
+	t.Run("rejects invalid IP", func(t *testing.T) {
+		if _, _, err := buildContainerProxyURL("not-an-ip", 80, "/", ""); err == nil {
+			t.Fatal("expected error for invalid IP")
+		}
+	})
+
+	t.Run("rejects invalid port", func(t *testing.T) {
+		if _, _, err := buildContainerProxyURL("10.0.0.1", 0, "/", ""); err == nil {
+			t.Fatal("expected error for port 0")
+		}
+		if _, _, err := buildContainerProxyURL("10.0.0.1", 70000, "/", ""); err == nil {
+			t.Fatal("expected error for port > 65535")
+		}
+	})
+
+	t.Run("rejects path that could rewrite authority", func(t *testing.T) {
+		if _, _, err := buildContainerProxyURL("10.0.0.1", 80, "//evil.com", ""); err == nil {
+			t.Fatal("expected error for scheme-relative path")
+		}
+		if _, _, err := buildContainerProxyURL("10.0.0.1", 80, "http://evil.com", ""); err == nil {
+			t.Fatal("expected error for absolute URL path")
+		}
+	})
+
+	t.Run("string form keeps authority fixed", func(t *testing.T) {
+		u, _, err := buildContainerProxyURL("172.18.0.2", 5000, "/api/v1", "x=y")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		parsed, err := url.Parse(u.String())
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if parsed.Hostname() != "172.18.0.2" || parsed.Port() != "5000" {
+			t.Fatalf("parsed authority = %s:%s", parsed.Hostname(), parsed.Port())
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Fixes CodeQL **go/request-forgery** (#8): *Uncontrolled data used in network request* in `HandleHTTPProxy` (`portforward.go`).

Previously the proxy URL was built with string concatenation:

```go
fmt.Sprintf("http://%s:%d%s", ipAddress, pf.ContainerPort, proxyPath)
```

User-controlled path/query could influence the request URL. This change:

1. **Validates** container IP (`net.ParseIP`) and port range before use
2. **Sanitizes** the proxy path (rooted path only; rejects `//…` and `\`)
3. **Builds** the target with `url.URL` so **Host is fixed** to the container address; path/query cannot rewrite authority
4. **Locks dialing** via a custom `Transport.DialContext` that always connects to that container `IP:port`
5. Keeps existing **no-follow-redirect** behavior

Adds unit tests for path sanitization and URL construction (IPv4/IPv6, rejection cases).

## Test plan
- [x] `go test ./internal/api/handlers/ -run 'TestSanitizeProxyPath|TestBuildContainerProxyURL' -v`
- [ ] CodeQL alert #8 dismissed/auto-closed after merge
- [ ] Manual: `/p/:forwardId/` still proxies a running container app
- [ ] Manual: path `//evil.com` returns bad-request style error page